### PR TITLE
tab, scroll, sizing tweaks

### DIFF
--- a/src/components/header/Tab.tsx
+++ b/src/components/header/Tab.tsx
@@ -1,0 +1,64 @@
+import { ListItemDecorator, IconButton, Tab as MuiTab, Stack } from '@mui/joy';
+import { Environment } from 'monaco-editor';
+import { useSelector } from 'react-redux';
+import {
+	selectEnvironments,
+	selectServices,
+	selectRequests,
+	selectEndpoints,
+	selectScripts,
+} from '../../state/active/selectors';
+import { closeTab } from '../../state/tabs/slice';
+import { ApplicationData, iconFromTabType } from '../../types/application-data/application-data';
+import { TabType } from '../../types/state/state';
+import { Close } from '@mui/icons-material';
+import { useAppDispatch } from '../../state/store';
+import { EllipsisTypography } from '../shared/EllipsisTypography';
+
+function getMapFromTabType<TTabType extends TabType>(data: Pick<ApplicationData, `${TTabType}s`>, tabType: TTabType) {
+	return data[`${tabType}s`];
+}
+
+interface TabProps {
+	tab: [string, TabType];
+}
+
+export function Tab({ tab: [tabId, tabType] }: TabProps) {
+	const environments = useSelector(selectEnvironments);
+	const services = useSelector(selectServices);
+	const requests = useSelector(selectRequests);
+	const endpoints = useSelector(selectEndpoints);
+	const scripts = useSelector(selectScripts);
+	const dispatch = useAppDispatch();
+	const tabData = getMapFromTabType({ environments, requests, services, endpoints, scripts }, tabType)[tabId];
+	const name = tabData?.name ?? (tabData as Environment)?.__name ?? '';
+	return (
+		<MuiTab
+			indicatorPlacement="top"
+			value={tabId}
+			id={`tab_${tabId}`}
+			sx={{
+				minWidth: 230,
+				maxWidth: 460,
+				scrollSnapAlign: 'start',
+			}}
+		>
+			<Stack direction="row" flexWrap="nowrap" alignItems="center" justifyContent="space-between" width="100%">
+				<ListItemDecorator sx={{ flex: 0 }}>{iconFromTabType[tabType]}</ListItemDecorator>
+				<EllipsisTypography>{name}</EllipsisTypography>
+				<ListItemDecorator sx={{ flex: 0 }}>
+					<IconButton
+						color="danger"
+						onClick={(e) => {
+							dispatch(closeTab(tabId));
+							e.stopPropagation();
+						}}
+						size="sm"
+					>
+						<Close />
+					</IconButton>
+				</ListItemDecorator>
+			</Stack>
+		</MuiTab>
+	);
+}

--- a/src/components/header/TabHeader.tsx
+++ b/src/components/header/TabHeader.tsx
@@ -1,33 +1,14 @@
 import { useEffect } from 'react';
-import { IconButton, ListItemDecorator, Sheet, Tab, TabList, TabPanel, Tabs, tabClasses } from '@mui/joy';
-import CloseIcon from '@mui/icons-material/Close';
+import { Sheet, TabPanel, Tabs } from '@mui/joy';
 
 import { useSelector } from 'react-redux';
-import { TabType } from '../../types/state/state';
-import { ApplicationData, Environment, iconFromTabType } from '../../types/application-data/application-data';
-import {
-	selectEnvironments,
-	selectServices,
-	selectRequests,
-	selectEndpoints,
-	selectScripts,
-} from '../../state/active/selectors';
 import { useAppDispatch } from '../../state/store';
 import { selectTabsState } from '../../state/tabs/selectors';
-import { setSelectedTab, closeTab } from '../../state/tabs/slice';
-import { keepStringLengthReasonable } from '../../utils/string';
+import { setSelectedTab } from '../../state/tabs/slice';
 import { TabContent } from '../panels/TabContent';
-
-function getMapFromTabType<TTabType extends TabType>(data: Pick<ApplicationData, `${TTabType}s`>, tabType: TTabType) {
-	return data[`${tabType}s`];
-}
+import { TabRow } from './TabRow';
 
 export function TabHeader() {
-	const environments = useSelector(selectEnvironments);
-	const services = useSelector(selectServices);
-	const requests = useSelector(selectRequests);
-	const endpoints = useSelector(selectEndpoints);
-	const scripts = useSelector(selectScripts);
 	const { list, selected } = useSelector(selectTabsState);
 	const dispatch = useAppDispatch();
 	useEffect(() => {
@@ -47,65 +28,7 @@ export function TabHeader() {
 					dispatch(setSelectedTab(newTabId));
 				}}
 			>
-				<TabList
-					tabFlex="1"
-					sticky="top"
-					underlinePlacement="bottom"
-					variant="soft"
-					disableUnderline
-					id="tabScroll"
-					sx={{
-						overflowX: 'auto',
-						overflowY: 'hidden',
-						scrollSnapType: 'x mandatory',
-						[`& .${tabClasses.root}`]: {
-							'&[aria-selected="true"]': {
-								color: `secondary.500`,
-								bgcolor: 'background.surface',
-								borderColor: 'divider',
-								outline: 'none',
-								'&::before': {
-									content: '""',
-									display: 'block',
-									position: 'absolute',
-									height: 2,
-									bottom: -2,
-									left: 0,
-									right: 0,
-									bgcolor: 'background.surface',
-								},
-							},
-						},
-					}}
-				>
-					{Object.entries(list).map(([tabId, tabType], index) => {
-						const tabData = getMapFromTabType({ environments, requests, services, endpoints, scripts }, tabType)[tabId];
-						const name = tabData?.name ?? (tabData as Environment)?.__name ?? '';
-						return (
-							<Tab
-								indicatorPlacement="top"
-								value={tabId}
-								key={index}
-								id={`tab_${tabId}`}
-								sx={{ minWidth: 230, flex: 'none', scrollSnapAlign: 'start' }}
-							>
-								<ListItemDecorator>{iconFromTabType[tabType]}</ListItemDecorator>
-								{keepStringLengthReasonable(name, 20)}
-								<ListItemDecorator>
-									<IconButton
-										color="danger"
-										onClick={(e) => {
-											dispatch(closeTab(tabId));
-											e.stopPropagation();
-										}}
-									>
-										<CloseIcon />
-									</IconButton>
-								</ListItemDecorator>
-							</Tab>
-						);
-					})}
-				</TabList>
+				<TabRow list={list} />
 				{Object.entries(list).map(([tabId, tabType], index) => (
 					<TabPanel value={tabId} key={index}>
 						<Sheet sx={{ boxSizing: 'content-box' }}>

--- a/src/components/header/TabRow.tsx
+++ b/src/components/header/TabRow.tsx
@@ -1,0 +1,50 @@
+import { TabList, tabClasses } from '@mui/joy';
+import { TabType } from '../../types/state/state';
+import { Tab } from './Tab';
+import { useHorizontalScroll } from '../../hooks/useHorizontalScroll';
+
+interface TabRowProps {
+	list: Record<string, TabType>;
+}
+
+export function TabRow({ list }: TabRowProps) {
+	const ref = useHorizontalScroll();
+	return (
+		<TabList
+			ref={ref}
+			tabFlex="1"
+			sticky="top"
+			underlinePlacement="bottom"
+			variant="soft"
+			disableUnderline
+			id="tabScroll"
+			sx={{
+				overflowX: 'auto',
+				overflowY: 'hidden',
+				scrollSnapType: 'x mandatory',
+				[`& .${tabClasses.root}`]: {
+					'&[aria-selected="true"]': {
+						color: `secondary.500`,
+						bgcolor: 'background.surface',
+						borderColor: 'divider',
+						outline: 'none',
+						'&::before': {
+							content: '""',
+							display: 'block',
+							position: 'absolute',
+							height: 2,
+							bottom: -2,
+							left: 0,
+							right: 0,
+							bgcolor: 'background.surface',
+						},
+					},
+				},
+			}}
+		>
+			{Object.entries(list).map((tab, index) => (
+				<Tab tab={tab} key={index} />
+			))}
+		</TabList>
+	);
+}

--- a/src/components/shared/EllipsisTypography.tsx
+++ b/src/components/shared/EllipsisTypography.tsx
@@ -1,0 +1,41 @@
+import { Box, Typography, TypographyProps } from '@mui/joy';
+import { PropsWithChildren } from 'react';
+
+export function EllipsisSpan({ children }: PropsWithChildren) {
+	return (
+		<Box
+			component="span"
+			sx={{
+				maxWidth: '100%',
+				width: '100%',
+				textOverflow: 'ellipsis',
+				textWrap: 'nowrap',
+				whiteSpace: 'nowrap',
+				overflow: 'hidden',
+			}}
+		>
+			{children}
+		</Box>
+	);
+}
+
+export function EllipsisTypography({ sx, children, ...props }: TypographyProps) {
+	return (
+		<Typography
+			{...props}
+			sx={{
+				flex: 1,
+				maxWidth: '100%',
+				width: '100%',
+				textOverflow: 'ellipsis',
+				textWrap: 'nowrap',
+				whiteSpace: 'nowrap',
+				overflow: 'hidden',
+				...sx,
+			}}
+			fontSize="sm"
+		>
+			{children}
+		</Typography>
+	);
+}

--- a/src/components/sidebar/SideDrawer.tsx
+++ b/src/components/sidebar/SideDrawer.tsx
@@ -21,13 +21,15 @@ export function SideDrawer({ open, children }: SideDrawerProps) {
 			/>
 			<Sheet
 				sx={{
-					minWidth: 256,
-					width: 'max-content',
+					minWidth: 350,
+					width: 400,
+					maxWidth: 700,
 					height: '100vh',
 					p: 2,
 					boxShadow: 'lg',
 					overflowY: 'scroll',
 					position: 'relative',
+					resize: 'horizontal',
 				}}
 			>
 				{children}

--- a/src/components/sidebar/file-system/EndpointFileSystem.tsx
+++ b/src/components/sidebar/file-system/EndpointFileSystem.tsx
@@ -13,7 +13,6 @@ import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import FolderIcon from '@mui/icons-material/Folder';
 import { RequestFileSystem } from './RequestFileSystem';
 import AddBoxIcon from '@mui/icons-material/AddBox';
-import { keepStringLengthReasonable } from '../../../utils/string';
 import { verbColors } from '../../../utils/style';
 import { useAppDispatch } from '../../../state/store';
 import { addNewEndpointById } from '../../../state/active/thunks/endpoints';
@@ -25,6 +24,7 @@ import { selectFilteredNestedIds, selectIsActiveTab } from '../../../state/tabs/
 import { FileSystemDropdown, menuOptionDelete, menuOptionDuplicate } from './FileSystemDropdown';
 import { SprocketTooltip } from '../../shared/SprocketTooltip';
 import { updateEndpoint } from '../../../state/active/slice';
+import { EllipsisTypography } from '../../shared/EllipsisTypography';
 
 interface EndpointFileSystemProps {
 	endpointId: string;
@@ -87,7 +87,9 @@ export function EndpointFileSystem({ endpointId }: EndpointFileSystemProps) {
 							</IconButton>
 						</SprocketTooltip>
 					</ListItemDecorator>
-					<ListItemContent>{keepStringLengthReasonable(endpoint.name)}</ListItemContent>
+					<ListItemContent>
+						<EllipsisTypography>{endpoint.name}</EllipsisTypography>
+					</ListItemContent>
 					<ListSubheader>
 						<Chip size="sm" variant="outlined" color={verbColors[endpoint.verb]}>
 							{endpoint.verb}

--- a/src/components/sidebar/file-system/RequestFileSystem.tsx
+++ b/src/components/sidebar/file-system/RequestFileSystem.tsx
@@ -1,6 +1,5 @@
 import { ListItem, ListItemButton, ListItemDecorator, ListSubheader } from '@mui/joy';
 import TextSnippetIcon from '@mui/icons-material/TextSnippet';
-import { keepStringLengthReasonable } from '../../../utils/string';
 import { useAppDispatch } from '../../../state/store';
 import { addNewRequestFromId } from '../../../state/active/thunks/requests';
 import { addTabs, addToDeleteQueue, setSelectedTab } from '../../../state/tabs/slice';
@@ -8,6 +7,7 @@ import { selectEndpointById, selectRequestsById } from '../../../state/active/se
 import { useSelector } from 'react-redux';
 import { selectIsActiveTab } from '../../../state/tabs/selectors';
 import { FileSystemDropdown, menuOptionDuplicate, menuOptionDelete } from './FileSystemDropdown';
+import { EllipsisSpan } from '../../shared/EllipsisTypography';
 
 interface RequestFileSystemProps {
 	requestId: string;
@@ -44,7 +44,9 @@ export function RequestFileSystem({ requestId }: RequestFileSystemProps) {
 				<ListItemDecorator>
 					<TextSnippetIcon fontSize="small" />
 				</ListItemDecorator>
-				<ListSubheader>{keepStringLengthReasonable(request.name)}</ListSubheader>
+				<ListSubheader sx={{ width: '100%' }}>
+					<EllipsisSpan>{request.name}</EllipsisSpan>
+				</ListSubheader>
 			</ListItemButton>
 		</ListItem>
 	);

--- a/src/components/sidebar/file-system/environment/EnvironmentFileSystem.tsx
+++ b/src/components/sidebar/file-system/environment/EnvironmentFileSystem.tsx
@@ -8,8 +8,8 @@ import { addNewEnvironmentById } from '../../../../state/active/thunks/environme
 import { useAppDispatch } from '../../../../state/store';
 import { selectIsActiveTab } from '../../../../state/tabs/selectors';
 import { addToDeleteQueue, addTabs, setSelectedTab } from '../../../../state/tabs/slice';
-import { keepStringLengthReasonable } from '../../../../utils/string';
 import { FileSystemDropdown, menuOptionDuplicate, menuOptionDelete } from '../FileSystemDropdown';
+import { EllipsisSpan } from '../../../shared/EllipsisTypography';
 
 interface EnvironmentFileSystemProps {
 	environmentId: string;
@@ -50,7 +50,9 @@ export function EnvironmentFileSystem({ environmentId }: EnvironmentFileSystemPr
 				<ListItemDecorator>
 					<TableChartIcon fontSize="small" />
 				</ListItemDecorator>
-				<ListSubheader>{keepStringLengthReasonable(environment.__name)}</ListSubheader>
+				<ListSubheader sx={{ width: '100%' }}>
+					<EllipsisSpan>{environment.__name}</EllipsisSpan>
+				</ListSubheader>
 			</ListItemButton>
 		</ListItem>
 	);

--- a/src/components/sidebar/file-system/script/ScriptFileSystem.tsx
+++ b/src/components/sidebar/file-system/script/ScriptFileSystem.tsx
@@ -4,10 +4,10 @@ import { selectScript } from '../../../../state/active/selectors';
 import { useAppDispatch } from '../../../../state/store';
 import { selectIsActiveTab } from '../../../../state/tabs/selectors';
 import { addToDeleteQueue, addTabs, setSelectedTab } from '../../../../state/tabs/slice';
-import { keepStringLengthReasonable } from '../../../../utils/string';
 import { FileSystemDropdown, menuOptionDuplicate, menuOptionDelete } from '../FileSystemDropdown';
 import CodeIcon from '@mui/icons-material/Code';
 import { createScript } from '../../../../state/active/thunks/scripts';
+import { EllipsisSpan } from '../../../shared/EllipsisTypography';
 
 interface ScriptFileSystemProps {
 	scriptId: string;
@@ -50,7 +50,9 @@ export function ScriptFileSystem({ scriptId }: ScriptFileSystemProps) {
 				<ListItemDecorator>
 					<CodeIcon fontSize="small" />
 				</ListItemDecorator>
-				<ListSubheader>{keepStringLengthReasonable(script.name)}</ListSubheader>
+				<ListSubheader sx={{ width: '100%' }}>
+					<EllipsisSpan>{script.name}</EllipsisSpan>
+				</ListSubheader>
 			</ListItemButton>
 		</ListItem>
 	);

--- a/src/components/sidebar/file-system/service/ServiceFileSystem.tsx
+++ b/src/components/sidebar/file-system/service/ServiceFileSystem.tsx
@@ -1,7 +1,6 @@
 import { Box, IconButton, List, ListItem, ListItemButton, ListItemDecorator, ListSubheader } from '@mui/joy';
 import FolderOpenSharpIcon from '@mui/icons-material/FolderOpenSharp';
 import FolderSharpIcon from '@mui/icons-material/FolderSharp';
-import { keepStringLengthReasonable } from '../../../../utils/string';
 import { EndpointFileSystem } from '../EndpointFileSystem';
 import AddBoxIcon from '@mui/icons-material/AddBox';
 import { useAppDispatch } from '../../../../state/store';
@@ -14,6 +13,7 @@ import { selectFilteredNestedIds, selectIsActiveTab } from '../../../../state/ta
 import { FileSystemDropdown, menuOptionDuplicate, menuOptionDelete } from '../FileSystemDropdown';
 import { SprocketTooltip } from '../../../shared/SprocketTooltip';
 import { updateService } from '../../../../state/active/slice';
+import { EllipsisSpan } from '../../../shared/EllipsisTypography';
 
 interface ServiceFileSystemProps {
 	serviceId: string;
@@ -75,7 +75,9 @@ export function ServiceFileSystem({ serviceId }: ServiceFileSystemProps) {
 							</IconButton>
 						</SprocketTooltip>
 					</ListItemDecorator>
-					<ListSubheader>{keepStringLengthReasonable(service.name)}</ListSubheader>
+					<ListSubheader sx={{ width: '100%' }}>
+						<EllipsisSpan>{service.name}</EllipsisSpan>
+					</ListSubheader>
 				</ListItemButton>
 				<List
 					aria-labelledby="nav-list-browse"

--- a/src/hooks/useHorizontalScroll.tsx
+++ b/src/hooks/useHorizontalScroll.tsx
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react';
+
+export function useHorizontalScroll() {
+	const scrollRef = useRef<HTMLDivElement | null>(null);
+	function scrollHorizontally(e: WheelEvent) {
+		if (scrollRef.current == null) return;
+		e.preventDefault();
+		// the best strat would be to get the one with the highest amplitude and use that
+		// but I don't want to atm
+		scrollRef.current.scrollBy({ left: e.deltaX + e.deltaY + e.deltaZ });
+	}
+	useEffect(() => {
+		scrollRef.current?.addEventListener('wheel', scrollHorizontally);
+		return () => scrollRef.current?.removeEventListener('wheel', scrollHorizontally);
+	});
+	return scrollRef;
+}


### PR DESCRIPTION
* Tabs are now a bit narrower and have the same font size as the side tree.
* Tabs have a max width and the text isn't centered. The x is on the far right.
* You can now scroll vertically to scroll horizontally in the tab list (ie mousewheel scrolls work like vscode)
* Ellipses are now determined by css and thus are dynamically ellipsoid
* Resizable sidebar (no saving the resize position yet)
