### PR TITLE
Remove roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,40 +23,20 @@ A tool for sending HTTP(S) requests over the internet. Similar to [Postman](http
 1. `yarn` (install dependancies)
 2. `yarn run start` (run locally)
 
-## Roadmap
+## Completed Features
 
-Key:
-☐: Ready to start
-❗: Work in progress
-✅: Complete
-
-- Add workspaces ✅
-- Import / Export work ✅
+- Add workspaces 
+- Import / Export
   - Imports from:
-    - Sprocket Pan ✅
-    - Postman ✅
-    - Insomnia ✅
-    - Swagger / OpenAPI ✅
-- Refactor global state ✅
-- Refactor Environment input/output (Janky) ✅
-- Show debug logs option in settings ☐
-- Scratchpad (Requests / Scripts not associated with a service) ❗
-  - Scripts ✅
-  - Requests ❗
-- Secrets Handling ☐
-  - Let certain fields in environments be secrets ☐
-  - Don't export secrets in exports ☐
-  - Maybe put secrets in a seperate file that can be gitignored? ☐
-  - Secret encryption when stored locally? idk ☐
-- Inputs/outputs besides JSON ❗
-  - Yaml / XML / HTML / raw text ✅
-  - Files ☐
-- Command Pallete ☐
-- Run Sprocket Pan in CLI ☐
+    - Sprocket Pan 
+    - Postman 
+    - Insomnia 
+    - Swagger / OpenAPI 
+- Scratchpad 
+  - Scripts 
+- Inputs/outputs besides JSON 
+  - Yaml / XML / HTML / raw text 
 - Automatic Updates (No need to redownload the program) ✅
 - Audit trail for requests ✅
-- Tabs ❗
-  - Dragging and Dropping ☐
-  - Favorites ☐
-  - Close all / all to the right/left ☐
+- Tabs 
   - Selection History ✅

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A tool for sending HTTP(S) requests over the internet. Similar to [Postman](http
   - Scripts 
 - Inputs/outputs besides JSON 
   - Yaml / XML / HTML / raw text 
-- Automatic Updates (No need to redownload the program) ✅
-- Audit trail for requests ✅
+- Automatic Updates (No need to redownload the program) 
+- Audit trail for requests 
 - Tabs 
-  - Selection History ✅
+  - Selection History 


### PR DESCRIPTION
Rationale: issues are much better for holding our plans and TODOs. So instead, we should list our accomplishments in place of a roadmap when we complete a feature that we like. We should expand it to include all relevant features, but that's outside of what I wanted to do here (I just want to deduplicate our various channels of where we shove our TODOs).