### PR TITLE
I lied, I got features in my bugfixes

### DIFF
--- a/src/classes/OrderedKeyValuePairs.ts
+++ b/src/classes/OrderedKeyValuePairs.ts
@@ -20,12 +20,27 @@ export class OrderedKeyValuePairs<T extends KeyValueValues = string> implements 
 		pairs.forEach(({ key, value }) => this.set(key, value));
 	}
 
+	public expand(pairs: KeyValueOrOrdered<T> | undefined) {
+		if (pairs == null) return;
+		if ('toArray' in pairs) {
+			pairs = pairs.toArray();
+		}
+		pairs.forEach(({ key, value }) => this.insertOnly(key, value));
+	}
+
 	public get(key: string) {
 		return this.map[key];
 	}
 
 	public findIndexOf(key: string) {
 		return this.order.findIndex((k) => k === key);
+	}
+
+	public insertOnly(key: string, value?: T) {
+		if (this.map[key] == null) {
+			this.order.push(key);
+			this.map[key] = value;
+		}
 	}
 
 	public set(key: string, value?: T) {

--- a/src/components/header/TabHeader.tsx
+++ b/src/components/header/TabHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Sheet, TabPanel, Tabs } from '@mui/joy';
 
 import { useSelector } from 'react-redux';
@@ -17,26 +17,31 @@ export function TabHeader() {
 		fileToScrollTo?.scrollIntoView({ block: 'center' });
 	}, [selected]);
 
+	const listList = useMemo(() => Object.entries(list), [list]);
+
 	return (
 		<div style={{ width: '100%', height: '100%', overflowY: 'auto', maxHeight: '100vh' }}>
-			<Tabs
-				aria-label="tabs"
-				size="lg"
-				value={selected}
-				onChange={(_event, newValue) => {
-					const newTabId = newValue as string;
-					dispatch(tabsActions.setSelectedTab(newTabId));
-				}}
-			>
-				<TabRow list={list} />
-				{Object.entries(list).map(([tabId, tabType], index) => (
-					<TabPanel value={tabId} key={index}>
-						<Sheet sx={{ boxSizing: 'content-box' }}>
-							<TabContent id={tabId} type={tabType} />
-						</Sheet>
-					</TabPanel>
-				))}
-			</Tabs>
+			{listList.length !== 0 && (
+				<Tabs
+					aria-label="tabs"
+					size="lg"
+					value={selected}
+					onChange={(_event, newValue) => {
+						const newTabId = newValue as string;
+						dispatch(tabsActions.setSelectedTab(newTabId));
+					}}
+					sx={{ height: '100%' }}
+				>
+					<TabRow list={list} />
+					{listList.map(([tabId, tabType], index) => (
+						<TabPanel value={tabId} key={index}>
+							<Sheet sx={{ boxSizing: 'content-box' }}>
+								<TabContent id={tabId} type={tabType} />
+							</Sheet>
+						</TabPanel>
+					))}
+				</Tabs>
+			)}
 		</div>
 	);
 }

--- a/src/components/header/TabRow.tsx
+++ b/src/components/header/TabRow.tsx
@@ -27,7 +27,6 @@ export function TabRow({ list }: TabRowProps) {
 						color: `secondary.500`,
 						bgcolor: 'background.surface',
 						borderColor: 'divider',
-						outline: 'none',
 						'&::before': {
 							content: '""',
 							display: 'block',

--- a/src/components/header/UndoRedoTabsButton.tsx
+++ b/src/components/header/UndoRedoTabsButton.tsx
@@ -12,7 +12,7 @@ export function UndoRedoTabsButton() {
 	const dispatch = useAppDispatch();
 
 	return (
-		<Stack direction={'row'} spacing={0} justifyContent={'flex-end'}>
+		<Stack direction="row" spacing={0} justifyContent={'flex-end'}>
 			<SprocketTooltip text="Previous Tab">
 				<IconButton
 					variant="outlined"

--- a/src/components/panels/endpoint/EndpointEditTabs.tsx
+++ b/src/components/panels/endpoint/EndpointEditTabs.tsx
@@ -1,35 +1,19 @@
 import { AccordionGroup, Tab, TabList, TabPanel, Tabs } from '@mui/joy';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
-import { EnvironmentContextResolver } from '../../../managers/EnvironmentContextResolver';
-import {
-	selectEnvironments,
-	selectSecrets,
-	selectSelectedEnvironmentValue,
-	selectServiceSelectedEnvironmentValue,
-} from '../../../state/active/selectors';
 import { updateEndpoint } from '../../../state/active/slice';
 import { useAppDispatch } from '../../../state/store';
 import { Endpoint } from '../../../types/application-data/application-data';
 import { camelCaseToTitle } from '../../../utils/string';
 import { PrePostScriptDisplay } from '../shared/PrePostScriptDisplay';
 import { EditableData } from '../../shared/input/EditableData';
+import { useComputedServiceEnvironment } from '../../../hooks/useComputedEnvironment';
 
 const endpointTabs = ['headers', 'queryParams', 'scripts'] as const;
 type EndpointPanelType = (typeof endpointTabs)[number];
 
 export function EndpointEditTabs({ endpoint }: { endpoint: Endpoint }) {
 	const [tab, setTab] = useState<EndpointPanelType>('headers');
-	const secrets = useSelector(selectSecrets);
-	const servEnv = useSelector((state) => selectServiceSelectedEnvironmentValue(state, endpoint.serviceId));
-	const rootEnv = useSelector(selectSelectedEnvironmentValue);
-	const environments = useSelector(selectEnvironments);
-	const envPairs = EnvironmentContextResolver.buildEnvironmentVariables({
-		secrets,
-		servEnv,
-		rootEnv,
-		rootAncestors: Object.values(environments),
-	}).toArray();
+	const envPairs = useComputedServiceEnvironment(endpoint.serviceId);
 	const dispatch = useAppDispatch();
 	function update(values: Partial<Endpoint>) {
 		dispatch(updateEndpoint({ ...values, id: endpoint.id }));

--- a/src/components/panels/endpoint/EndpointEditTabs.tsx
+++ b/src/components/panels/endpoint/EndpointEditTabs.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { EnvironmentContextResolver } from '../../../managers/EnvironmentContextResolver';
 import {
+	selectEnvironments,
 	selectSecrets,
 	selectSelectedEnvironmentValue,
 	selectServiceSelectedEnvironmentValue,
@@ -22,7 +23,13 @@ export function EndpointEditTabs({ endpoint }: { endpoint: Endpoint }) {
 	const secrets = useSelector(selectSecrets);
 	const servEnv = useSelector((state) => selectServiceSelectedEnvironmentValue(state, endpoint.serviceId));
 	const rootEnv = useSelector(selectSelectedEnvironmentValue);
-	const envPairs = EnvironmentContextResolver.buildEnvironmentVariables({ secrets, servEnv, rootEnv }).toArray();
+	const environments = useSelector(selectEnvironments);
+	const envPairs = EnvironmentContextResolver.buildEnvironmentVariables({
+		secrets,
+		servEnv,
+		rootEnv,
+		rootAncestors: Object.values(environments),
+	}).toArray();
 	const dispatch = useAppDispatch();
 	function update(values: Partial<Endpoint>) {
 		dispatch(updateEndpoint({ ...values, id: endpoint.id }));
@@ -47,14 +54,14 @@ export function EndpointEditTabs({ endpoint }: { endpoint: Endpoint }) {
 
 			<TabPanel value="headers">
 				<EditableData
-					values={endpoint.baseHeaders}
+					initialValues={endpoint.baseHeaders}
 					onChange={(baseHeaders) => update({ baseHeaders })}
 					envPairs={envPairs}
 				/>
 			</TabPanel>
 			<TabPanel value="queryParams">
 				<EditableData
-					values={endpoint.baseQueryParams}
+					initialValues={endpoint.baseQueryParams}
 					onChange={(baseQueryParams) => update({ baseQueryParams })}
 					envPairs={envPairs}
 				/>

--- a/src/components/panels/endpoint/EndpointPanel.tsx
+++ b/src/components/panels/endpoint/EndpointPanel.tsx
@@ -52,14 +52,15 @@ export function EndpointPanel({ id }: PanelProps) {
 	}
 
 	return (
-		<>
+		<Stack gap={2}>
 			<EditableText
+				sx={{ margin: 'auto' }}
 				text={endpoint.name}
 				setText={(newText: string) => update({ name: newText })}
 				isValidFunc={(text: string) => text.length >= 1}
-				isTitle
+				level="h2"
 			/>
-			<Grid container spacing={2} sx={{ paddingTop: '30px' }} alignItems="center" justifyContent={'center'}>
+			<Grid container spacing={2} alignItems="center" justifyContent={'center'}>
 				<Grid xs={2}>
 					<Select
 						value={endpoint.verb}
@@ -95,7 +96,7 @@ export function EndpointPanel({ id }: PanelProps) {
 					></Input>
 				</Grid>
 				<Grid xs={2}>
-					<Stack direction={'row'} spacing={2}>
+					<Stack direction="row" spacing={2}>
 						<Button
 							color="primary"
 							startDecorator={<ExitToAppIcon />}
@@ -113,6 +114,6 @@ export function EndpointPanel({ id }: PanelProps) {
 				</Grid>
 			</Grid>
 			<EndpointEditTabs endpoint={endpoint} />
-		</>
+		</Stack>
 	);
 }

--- a/src/components/panels/environment/EnvironmentPanel.tsx
+++ b/src/components/panels/environment/EnvironmentPanel.tsx
@@ -3,7 +3,7 @@ import { selectEnvironments, selectSecrets, selectSelectedEnvironment } from '..
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from '../../../state/store';
 import { selectEnvironment, updateEnvironment } from '../../../state/active/slice';
-import { Typography } from '@mui/joy';
+import { Stack, Typography } from '@mui/joy';
 import { Box } from '@mui/joy';
 import { EditableText } from '../../shared/input/EditableText';
 import { PanelProps } from '../panels.interface';
@@ -21,8 +21,9 @@ export function EnvironmentPanel({ id }: PanelProps) {
 	}
 
 	return (
-		<>
+		<Stack gap={2}>
 			<EditableText
+				sx={{ margin: 'auto' }}
 				text={environment.name}
 				setText={(newText: string) => dispatch(updateEnvironment({ name: newText, id }))}
 				isValidFunc={(text: string) =>
@@ -31,21 +32,26 @@ export function EnvironmentPanel({ id }: PanelProps) {
 						.filter((env) => env.id != id)
 						.filter((env) => env.name === text).length === 0
 				}
-				isTitle
-			/>
-			<Checkbox
-				label="Selected"
-				checked={selectedEnvironment === id}
-				onChange={() => dispatch(selectEnvironment(selectedEnvironment === id ? undefined : id))}
+				level="h2"
 			/>
 			<Box sx={{ height: '70vh', pb: '5vh' }}>
 				<EditableData
+					actions={{
+						start: (
+							<Checkbox
+								sx={{ my: 1 }}
+								label="Selected"
+								checked={selectedEnvironment === id}
+								onChange={() => dispatch(selectEnvironment(selectedEnvironment === id ? undefined : id))}
+							/>
+						),
+					}}
 					values={environment.pairs}
 					onChange={(pairs) => dispatch(updateEnvironment({ pairs, id }))}
 					fullSize
 					envPairs={secrets}
 				/>
 			</Box>
-		</>
+		</Stack>
 	);
 }

--- a/src/components/panels/environment/EnvironmentPanel.tsx
+++ b/src/components/panels/environment/EnvironmentPanel.tsx
@@ -3,11 +3,15 @@ import { selectEnvironments, selectSecrets, selectSelectedEnvironment } from '..
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from '../../../state/store';
 import { selectEnvironment, updateEnvironment } from '../../../state/active/slice';
-import { Stack, Typography } from '@mui/joy';
+import { Option, Select, Stack, Typography } from '@mui/joy';
 import { Box } from '@mui/joy';
 import { EditableText } from '../../shared/input/EditableText';
 import { PanelProps } from '../panels.interface';
-import { EditableData } from '../../shared/input/EditableData';
+import { EditableData, parseEditorJSON, toEditorJSON } from '../../shared/input/EditableData';
+import { useMemo } from 'react';
+import { AccountTree } from '@mui/icons-material';
+import { EnvironmentContextResolver } from '../../../managers/EnvironmentContextResolver';
+import { toKeyValuePairs } from '../../../utils/application';
 
 export function EnvironmentPanel({ id }: PanelProps) {
 	const selectedEnvironment = useSelector(selectSelectedEnvironment);
@@ -16,8 +20,23 @@ export function EnvironmentPanel({ id }: PanelProps) {
 	const secrets = useSelector(selectSecrets);
 	const dispatch = useAppDispatch();
 
+	const envList = useMemo(
+		() => Object.values(environments).filter((env) => env.id !== environment?.id),
+		[environments],
+	);
+
 	if (environment == null) {
 		return <Typography>No Environment Found</Typography>;
+	}
+
+	function parseEditorText(text: string) {
+		const pairs = toKeyValuePairs<string>(parseEditorJSON(text));
+		const parsedPairs = EnvironmentContextResolver.buildEnvironmentVariables({
+			secrets,
+			rootEnv: { ...environment, pairs },
+			rootAncestors: Object.values(environments),
+		});
+		return toEditorJSON(parsedPairs.toArray());
 	}
 
 	return (
@@ -26,30 +45,42 @@ export function EnvironmentPanel({ id }: PanelProps) {
 				sx={{ margin: 'auto' }}
 				text={environment.name}
 				setText={(newText: string) => dispatch(updateEnvironment({ name: newText, id }))}
-				isValidFunc={(text: string) =>
-					text.length >= 1 &&
-					Object.values(environments)
-						.filter((env) => env.id != id)
-						.filter((env) => env.name === text).length === 0
-				}
+				isValidFunc={(text: string) => text.length >= 1}
 				level="h2"
 			/>
 			<Box sx={{ height: '70vh', pb: '5vh' }}>
 				<EditableData
 					actions={{
 						start: (
-							<Checkbox
-								sx={{ my: 1 }}
-								label="Selected"
-								checked={selectedEnvironment === id}
-								onChange={() => dispatch(selectEnvironment(selectedEnvironment === id ? undefined : id))}
-							/>
+							<>
+								<Checkbox
+									sx={{ m: 1 }}
+									label="Selected"
+									checked={selectedEnvironment === id}
+									onChange={() => dispatch(selectEnvironment(selectedEnvironment === id ? undefined : id))}
+								/>
+								<Select
+									startDecorator={<AccountTree />}
+									sx={{ minWidth: '250px' }}
+									placeholder="None"
+									multiple
+									value={environment.parents ?? []}
+									onChange={(_, parents) => dispatch(updateEnvironment({ parents, id }))}
+								>
+									{envList.map((env) => (
+										<Option key={env.id} value={env.id}>
+											{env.name}
+										</Option>
+									))}
+								</Select>
+							</>
 						),
 					}}
-					values={environment.pairs}
+					initialValues={environment.pairs}
 					onChange={(pairs) => dispatch(updateEnvironment({ pairs, id }))}
 					fullSize
 					envPairs={secrets}
+					viewParser={parseEditorText}
 				/>
 			</Box>
 		</Stack>

--- a/src/components/panels/request/RequestActions.tsx
+++ b/src/components/panels/request/RequestActions.tsx
@@ -116,7 +116,7 @@ export function RequestActions({ endpoint, request, onError, onResponse }: Reque
 				</Card>
 			</Grid>
 			<Grid xs={5} xl={3}>
-				<Stack direction={'row'} spacing={2}>
+				<Stack direction="row" spacing={2}>
 					<Button
 						color={isLoading ? 'warning' : 'primary'}
 						startDecorator={isLoading ? <CircularProgress /> : <SendIcon />}

--- a/src/components/panels/request/RequestEditTabs.tsx
+++ b/src/components/panels/request/RequestEditTabs.tsx
@@ -1,5 +1,4 @@
-import { AccordionGroup, Tab, TabList, TabPanel, Tabs } from '@mui/joy';
-import { useState } from 'react';
+import { AccordionGroup } from '@mui/joy';
 import { RequestBody } from './RequestBody';
 import { useSelector } from 'react-redux';
 import { EnvironmentContextResolver } from '../../../managers/EnvironmentContextResolver';
@@ -8,80 +7,81 @@ import {
 	selectSelectedEnvironmentValue,
 	selectServiceSelectedEnvironmentValue,
 	selectEndpointById,
+	selectEnvironments,
 } from '../../../state/active/selectors';
 import { updateRequest } from '../../../state/active/slice';
 import { useAppDispatch } from '../../../state/store';
 import { EndpointRequest } from '../../../types/application-data/application-data';
-import { camelCaseToTitle } from '../../../utils/string';
 import { PrePostScriptDisplay } from '../shared/PrePostScriptDisplay';
 import { EditableData } from '../../shared/input/EditableData';
-
-const requestTabs = ['body', 'headers', 'queryParams', 'scripts', 'environment'] as const;
-type RequestTabType = (typeof requestTabs)[number];
+import { SprocketTabs } from '../../shared/SprocketTabs';
 
 export function RequestEditTabs({ request }: { request: EndpointRequest }) {
-	const [tab, setTab] = useState<RequestTabType>('body');
 	const secrets = useSelector(selectSecrets);
 	const reqEnv = request.environmentOverride;
 	const rootEnv = useSelector(selectSelectedEnvironmentValue);
 	const endpoint = useSelector((state) => selectEndpointById(state, request.endpointId));
 	const servEnv = useSelector((state) => selectServiceSelectedEnvironmentValue(state, endpoint.serviceId));
+	const environments = useSelector(selectEnvironments);
 	const envPairs = EnvironmentContextResolver.buildEnvironmentVariables({
 		reqEnv,
 		secrets,
 		rootEnv,
 		servEnv,
+		rootAncestors: Object.values(environments),
 	}).toArray();
 	const dispatch = useAppDispatch();
 	function update(values: Partial<EndpointRequest>) {
 		dispatch(updateRequest({ ...values, id: request.id }));
 	}
+
 	return (
-		<Tabs
-			aria-label="tabs"
-			size="lg"
-			value={tab}
-			onChange={(_event, newValue) => {
-				const newTabId = newValue as RequestTabType;
-				setTab(newTabId);
-			}}
-		>
-			<TabList color="primary">
-				{requestTabs.map((curTab, index) => (
-					<Tab color={curTab === tab ? 'primary' : 'neutral'} value={curTab} key={index}>
-						{camelCaseToTitle(curTab)}
-					</Tab>
-				))}
-			</TabList>
-			<TabPanel value={'body'}>
-				<RequestBody request={request}></RequestBody>
-			</TabPanel>
-			<TabPanel value="headers">
-				<EditableData values={request.headers} onChange={(values) => update({ headers: values })} envPairs={envPairs} />
-			</TabPanel>
-			<TabPanel value="queryParams">
-				<EditableData
-					values={request.queryParams}
-					onChange={(queryParams) => update({ queryParams })}
-					envPairs={envPairs}
-				/>
-			</TabPanel>
-			<TabPanel value="scripts">
-				<AccordionGroup>
-					<PrePostScriptDisplay
-						onChange={update}
-						preRequestScript={request.preRequestScript}
-						postRequestScript={request.postRequestScript}
-					/>
-				</AccordionGroup>
-			</TabPanel>
-			<TabPanel value="environment">
-				<EditableData
-					values={request.environmentOverride?.pairs ?? []}
-					onChange={(pairs) => update({ environmentOverride: { ...request.environmentOverride, pairs } })}
-					envPairs={envPairs}
-				/>
-			</TabPanel>
-		</Tabs>
+		<SprocketTabs
+			tabs={[
+				{ title: 'Body', content: <RequestBody request={request} /> },
+				{
+					title: 'Headers',
+					content: (
+						<EditableData
+							initialValues={request.headers}
+							onChange={(values) => update({ headers: values })}
+							envPairs={envPairs}
+						/>
+					),
+				},
+				{
+					title: 'Query Params',
+					content: (
+						<EditableData
+							initialValues={request.queryParams}
+							onChange={(queryParams) => update({ queryParams })}
+							envPairs={envPairs}
+						/>
+					),
+				},
+				{
+					title: 'Scripts',
+					content: (
+						<AccordionGroup>
+							<PrePostScriptDisplay
+								onChange={update}
+								preRequestScript={request.preRequestScript}
+								postRequestScript={request.postRequestScript}
+							/>
+						</AccordionGroup>
+					),
+				},
+				{
+					title: 'Environment',
+					content: (
+						<EditableData
+							initialValues={request.environmentOverride?.pairs ?? []}
+							onChange={(pairs) => update({ environmentOverride: { ...request.environmentOverride, pairs } })}
+							envPairs={envPairs}
+						/>
+					),
+				},
+			]}
+		/>
 	);
 }

--- a/src/components/panels/request/RequestEditTabs.tsx
+++ b/src/components/panels/request/RequestEditTabs.tsx
@@ -1,35 +1,15 @@
 import { AccordionGroup } from '@mui/joy';
 import { RequestBody } from './RequestBody';
-import { useSelector } from 'react-redux';
-import { EnvironmentContextResolver } from '../../../managers/EnvironmentContextResolver';
-import {
-	selectSecrets,
-	selectSelectedEnvironmentValue,
-	selectServiceSelectedEnvironmentValue,
-	selectEndpointById,
-	selectEnvironments,
-} from '../../../state/active/selectors';
 import { updateRequest } from '../../../state/active/slice';
 import { useAppDispatch } from '../../../state/store';
 import { EndpointRequest } from '../../../types/application-data/application-data';
 import { PrePostScriptDisplay } from '../shared/PrePostScriptDisplay';
 import { EditableData } from '../../shared/input/EditableData';
 import { SprocketTabs } from '../../shared/SprocketTabs';
+import { useComputedRequestEnvironment } from '../../../hooks/useComputedEnvironment';
 
 export function RequestEditTabs({ request }: { request: EndpointRequest }) {
-	const secrets = useSelector(selectSecrets);
-	const reqEnv = request.environmentOverride;
-	const rootEnv = useSelector(selectSelectedEnvironmentValue);
-	const endpoint = useSelector((state) => selectEndpointById(state, request.endpointId));
-	const servEnv = useSelector((state) => selectServiceSelectedEnvironmentValue(state, endpoint.serviceId));
-	const environments = useSelector(selectEnvironments);
-	const envPairs = EnvironmentContextResolver.buildEnvironmentVariables({
-		reqEnv,
-		secrets,
-		rootEnv,
-		servEnv,
-		rootAncestors: Object.values(environments),
-	}).toArray();
+	const envPairs = useComputedRequestEnvironment(request.id);
 	const dispatch = useAppDispatch();
 	function update(values: Partial<EndpointRequest>) {
 		dispatch(updateRequest({ ...values, id: request.id }));

--- a/src/components/panels/request/RequestPanel.tsx
+++ b/src/components/panels/request/RequestPanel.tsx
@@ -31,13 +31,14 @@ export function RequestPanel({ id }: PanelProps) {
 	return (
 		<>
 			<EditableText
+				sx={{ margin: 'auto' }}
 				text={request.name}
 				setText={(newText: string) => update({ name: newText })}
 				isValidFunc={(text: string) => text.length >= 1}
-				isTitle
+				level="h2"
 			/>
 			<RequestActions endpoint={endpoint} request={request} onError={setLastError} onResponse={setResponseState} />
-			<Grid container direction={'row'} spacing={1} sx={{ height: '100%' }}>
+			<Grid container direction="row" spacing={1} sx={{ height: '100%' }}>
 				<Grid xs={6}>
 					<Card sx={{ height: '100%', width: '100%' }}>
 						<Typography level="h3" sx={{ textAlign: 'center' }}>

--- a/src/components/panels/request/response/HeadersDisplayTable.tsx
+++ b/src/components/panels/request/response/HeadersDisplayTable.tsx
@@ -1,15 +1,16 @@
 import { AccordionGroup, Accordion, AccordionSummary, AccordionDetails, Table } from '@mui/joy';
 import { KeyValuePair } from '../../../../classes/OrderedKeyValuePairs';
+import { toKeyValuePairs } from '../../../../utils/application';
 
 interface HeadersDisplayTableProps {
-	headers?: KeyValuePair[] | null;
+	headers?: KeyValuePair[] | null | Record<string, string>;
 	label: 'request' | 'response';
 }
 
 export function HeadersDisplayTable({ headers, label }: HeadersDisplayTableProps) {
-	if (headers == null || headers.length === 0) {
-		return <></>;
-	}
+	if (headers == null) return <></>;
+	headers = Array.isArray(headers) ? headers : toKeyValuePairs(headers);
+	if (headers.length === 0) return <></>;
 	return (
 		<AccordionGroup>
 			<Accordion defaultExpanded>

--- a/src/components/panels/request/response/HistoryControl.tsx
+++ b/src/components/panels/request/response/HistoryControl.tsx
@@ -19,7 +19,7 @@ export function HistoryControl({ value, onChange, historyLength, onDelete }: His
 	// and 'latest' is identical to historyLength - 1
 	const numValue = value === 'latest' ? historyLength - 1 : value === 'error' ? historyLength : value;
 	return (
-		<Stack direction={'row'}>
+		<Stack direction="row">
 			<SprocketTooltip text={'Previous Response'}>
 				<IconButton
 					aria-label="Previous Response"
@@ -35,7 +35,6 @@ export function HistoryControl({ value, onChange, historyLength, onDelete }: His
 				) : (
 					<>
 						<EditableText
-							sx={{ display: 'flex', alignItems: 'center' }}
 							text={`${numValue + 1}`}
 							setText={(text: string) => {
 								const num = Number.parseInt(text);
@@ -45,6 +44,7 @@ export function HistoryControl({ value, onChange, historyLength, onDelete }: His
 								const num = Number.parseInt(text);
 								return !isNaN(num) && num >= 1 && num <= historyLength;
 							}}
+							narrow
 						/>
 						/{historyLength}
 					</>

--- a/src/components/panels/request/response/ResponseInfo.tsx
+++ b/src/components/panels/request/response/ResponseInfo.tsx
@@ -17,6 +17,8 @@ import { HistoricalEndpointResponse } from '../../../../types/application-data/a
 import { ValuesOf } from '../../../../types/utils/utils';
 import { formatFullDate, camelCaseToTitle } from '../../../../utils/string';
 import { statusCodes } from '../../../../constants/statusCodes';
+import { UriTypography } from '../../../shared/UriTypography';
+import { toKeyValuePairs } from '../../../../utils/application';
 
 const responseTabs = ['body', 'details', 'request', 'eventLog'] as const;
 type ResponseTabType = ValuesOf<typeof responseTabs>;
@@ -63,7 +65,7 @@ export function ResponseInfo({ response, requestId }: ResponseInfoProps) {
 			<TabPanel value="request">
 				<Typography left="p" sx={{ mb: 2 }}>
 					At <u>{formatFullDate(new Date(response.request.dateTime))}</u>, a <u>{response.request.method}</u> request
-					was sent to <u>{response.request.url}</u>.
+					was sent to <UriTypography>{response.request.url}</UriTypography>.
 				</Typography>
 				<HeadersDisplayTable headers={response.request.headers} label="request" />
 				{Object.keys(response.request.body).length > 0 && (
@@ -75,6 +77,7 @@ export function ResponseInfo({ response, requestId }: ResponseInfoProps) {
 									<ResponseBody
 										response={{
 											...response.request,
+											headers: toKeyValuePairs(response.request.headers),
 											bodyType: response.request.bodyType ?? 'JSON',
 											statusCode: 0,
 											body: response.request.body,

--- a/src/components/panels/request/response/ResponsePanel.tsx
+++ b/src/components/panels/request/response/ResponsePanel.tsx
@@ -41,7 +41,7 @@ export function ResponsePanel({ responseState, request, setResponseState, lastEr
 						<Typography level="title-md" textAlign={'center'}>
 							{formatFullDate(new Date(responseStateData?.response.dateTime))}
 						</Typography>
-						<Stack direction={'row'} spacing={0}>
+						<Stack direction="row" spacing={0}>
 							<OpenDiffToolButton
 								historyIndex={
 									typeof responseState === 'number' ? responseState : Math.max(request.history.length - 1, 0)

--- a/src/components/panels/script/ScriptPanel.tsx
+++ b/src/components/panels/script/ScriptPanel.tsx
@@ -137,12 +137,13 @@ export function ScriptPanel({ id }: PanelProps) {
 	return (
 		<>
 			<EditableText
+				sx={{ margin: 'auto' }}
 				text={script.name}
 				setText={(newText: string) => update({ name: newText, id, scriptCallableName: toValidFunctionName(newText) })}
 				isValidFunc={(text: string) => text.length >= 1 && (!scriptNames.has(text) || text == script.name)}
-				isTitle
+				level="h2"
 			/>
-			<Stack direction={'row'} spacing={2}>
+			<Stack direction="row" spacing={2}>
 				<FormControl>
 					<FormLabel>Script-Callable Name</FormLabel>
 					<Input
@@ -261,7 +262,7 @@ export function ScriptPanel({ id }: PanelProps) {
 					)}
 				</FormControl>
 			</Stack>
-			<Stack direction={'row'} spacing={2}>
+			<Stack direction="row" spacing={2}>
 				<FormatButton onChange={format} />
 				<CopyToClipboardButton copyText={localDataState} />
 			</Stack>

--- a/src/components/panels/script/ScriptPanel.tsx
+++ b/src/components/panels/script/ScriptPanel.tsx
@@ -14,7 +14,6 @@ import {
 	Select,
 	Stack,
 	Typography,
-	useColorScheme,
 } from '@mui/joy';
 import { Editor, Monaco } from '@monaco-editor/react';
 import { useState, useRef, useEffect } from 'react';
@@ -40,6 +39,7 @@ import HourglassTopIcon from '@mui/icons-material/HourglassTop';
 import ThumbUpOffAltIcon from '@mui/icons-material/ThumbUpOffAlt';
 import { Constants } from '../../../constants/constants';
 import { FormatButton } from '../../shared/buttons/FormatButton';
+import { useEditorTheme } from '../../../hooks/useEditorTheme';
 
 const iconMap: Record<'function' | 'variable' | 'class', JSX.Element> = {
 	function: <FunctionsIcon />,
@@ -48,11 +48,10 @@ const iconMap: Record<'function' | 'variable' | 'class', JSX.Element> = {
 };
 
 export function ScriptPanel({ id }: PanelProps) {
+	const theme = useEditorTheme();
 	const script = useSelector((state) => selectScript(state, id));
 	const scripts = useSelector(selectScripts);
 	const scriptNames = new Set(Object.values(scripts).map((script) => script.name));
-	const { mode, systemMode } = useColorScheme();
-	const resolvedMode = mode === 'system' ? systemMode : mode;
 	const [isRunning, setRunning] = useState(false);
 	const [isDebouncing, setDebouncing] = useState(false);
 	const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
@@ -275,7 +274,7 @@ export function ScriptPanel({ id }: PanelProps) {
 					}
 				}}
 				language={'typescript'}
-				theme={resolvedMode === 'dark' ? 'vs-dark' : resolvedMode}
+				theme={theme}
 				options={defaultEditorOptions}
 				onMount={handleMainEditorDidMount}
 			/>
@@ -286,7 +285,7 @@ export function ScriptPanel({ id }: PanelProps) {
 				height={'15vh'}
 				value={scriptOutput}
 				language={scriptOutputLang}
-				theme={resolvedMode === 'dark' ? 'vs-dark' : resolvedMode}
+				theme={theme}
 				options={{ readOnly: true, domReadOnly: true, ...defaultEditorOptions }}
 				onMount={handleReturnEditorDidMount}
 			/>

--- a/src/components/panels/secrets/SecretsPanel.tsx
+++ b/src/components/panels/secrets/SecretsPanel.tsx
@@ -11,7 +11,7 @@ export function SecretsPanel({ id }: PanelProps) {
 	const dispatch = useAppDispatch();
 	return (
 		<Box sx={{ height: '70vh', pb: '5vh' }}>
-			<EditableData values={secrets} onChange={(values) => dispatch(updateSecrets(values))} fullSize />
+			<EditableData initialValues={secrets} onChange={(values) => dispatch(updateSecrets(values))} fullSize />
 		</Box>
 	);
 }

--- a/src/components/panels/service/EnvironmentEditor.tsx
+++ b/src/components/panels/service/EnvironmentEditor.tsx
@@ -1,0 +1,91 @@
+import { IconButton } from '@mui/joy';
+import { KeyValuePair } from '../../../classes/OrderedKeyValuePairs';
+import { Environment } from '../../../types/application-data/application-data';
+import { EditableData } from '../../shared/input/EditableData';
+import { EditableText } from '../../shared/input/EditableText';
+import { SprocketTooltip } from '../../shared/SprocketTooltip';
+import { Delete, FileCopy, RadioButtonChecked, RadioButtonUnchecked } from '@mui/icons-material';
+
+import { useEffect, useState } from 'react';
+import { AreYouSureModal } from '../../shared/modals/AreYouSureModal';
+
+interface EnvironmentEditorProps {
+	serviceId: string;
+	env: Environment;
+	envPairs: KeyValuePair[];
+	onChange: (values: Partial<Environment>) => void;
+	onDelete: () => void;
+	onClone: (values: Partial<Environment>) => void;
+	selected: boolean;
+	toggleSelected: (() => void) | null;
+}
+
+export function EnvironmentEditor({
+	env,
+	envPairs,
+	onChange,
+	onDelete,
+	onClone,
+	selected,
+	toggleSelected,
+}: EnvironmentEditorProps) {
+	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+	// start Editor bug workaround
+	const [isForcedRerender, setIsForcedRerender] = useState(false);
+	useEffect(() => {
+		setIsForcedRerender(true);
+	}, [env.id, envPairs]);
+	useEffect(() => {
+		if (isForcedRerender) setIsForcedRerender(false);
+	}, [isForcedRerender]);
+	if (isForcedRerender) return null;
+	// end Editor bug workaround
+
+	return (
+		<>
+			<EditableData
+				actions={{
+					middle: (
+						<EditableText
+							text={env.name}
+							setText={(name) => onChange({ name })}
+							isValidFunc={(text) => text !== ''}
+							color={selected ? 'primary' : 'neutral'}
+						/>
+					),
+					start: (
+						<>
+							{toggleSelected != null && (
+								<SprocketTooltip text={selected ? 'Unselect' : 'Select'}>
+									<IconButton onClick={toggleSelected}>
+										{selected ? <RadioButtonChecked /> : <RadioButtonUnchecked />}
+									</IconButton>
+								</SprocketTooltip>
+							)}
+							<SprocketTooltip text="Duplicate">
+								<IconButton onClick={() => onClone(env)}>
+									<FileCopy />
+								</IconButton>
+							</SprocketTooltip>
+							<SprocketTooltip text="Delete">
+								<IconButton onClick={() => setIsDeleteModalOpen(true)}>
+									<Delete />
+								</IconButton>
+							</SprocketTooltip>
+						</>
+					),
+				}}
+				initialValues={env.pairs}
+				onChange={(pairs) => onChange({ pairs })}
+				envPairs={envPairs}
+			/>
+			<AreYouSureModal
+				open={isDeleteModalOpen}
+				action={`delete ${env.name ?? env.id}`}
+				actionFunc={onDelete}
+				closeFunc={() => setIsDeleteModalOpen(false)}
+			></AreYouSureModal>
+		</>
+	);
+}

--- a/src/components/panels/service/EnvironmentsSection.tsx
+++ b/src/components/panels/service/EnvironmentsSection.tsx
@@ -1,35 +1,32 @@
 import { useState } from 'react';
-import { Box, IconButton, Select, Stack, Option } from '@mui/joy';
+import { IconButton, Select, Stack, Option, Box, Divider } from '@mui/joy';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
-import DeleteIcon from '@mui/icons-material/Delete';
-import FileCopyIcon from '@mui/icons-material/FileCopy';
-import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
-import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
-
 import { useSelector } from 'react-redux';
 import { EnvironmentContextResolver } from '../../../managers/EnvironmentContextResolver';
-import { selectSecrets, selectSelectedEnvironmentValue } from '../../../state/active/selectors';
+import { selectEnvironments, selectSecrets, selectSelectedEnvironmentValue } from '../../../state/active/selectors';
 import { SprocketTooltip } from '../../shared/SprocketTooltip';
-import { EditableText } from '../../shared/input/EditableText';
-import { AreYouSureModal } from '../../shared/modals/AreYouSureModal';
-import { EditableData } from '../../shared/input/EditableData';
 import { SectionProps } from './sectionProps';
 import { Environment } from '../../../types/application-data/application-data';
 import { cloneEnv } from '../../../utils/application';
-import { Link } from '@mui/icons-material';
+import { EnvironmentEditor } from './EnvironmentEditor';
+import { Link, LinkOff, ModeEdit } from '@mui/icons-material';
+import { LinkedEnvironmentEditor } from './LinkedEnvironmentEditor';
 
 export function EnvironmentsSection({ data, onChange }: SectionProps) {
+	const [visibleEnvId, setVisibleEnvId] = useState<string | null>(data.selectedEnvironment ?? null);
 	const secrets = useSelector(selectSecrets);
 	const rootEnv = useSelector(selectSelectedEnvironmentValue);
-	const [envToDelete, setEnvToDelete] = useState<string | null>(null);
-	const [visibleEnvId, setVisibleEnvId] = useState<string | null>(data.selectedEnvironment ?? null);
 	const localEnvs = data.localEnvironments;
+	const envList = Object.values(localEnvs);
+	const visibleEnv = visibleEnvId == null ? null : data.localEnvironments[visibleEnvId];
+	const isVisibleSelected = data.selectedEnvironment === visibleEnvId;
+	const environments = useSelector(selectEnvironments);
 
-	const envPairs = EnvironmentContextResolver.buildEnvironmentVariables({ rootEnv, secrets }).toArray();
-
-	function modifyEnv(id: string, content: Partial<Environment>) {
-		onChange({ localEnvironments: { ...localEnvs, [id]: { ...localEnvs[id], ...content } } });
-	}
+	const envPairs = EnvironmentContextResolver.buildEnvironmentVariables({
+		rootEnv,
+		secrets,
+		rootAncestors: Object.values(environments),
+	}).toArray();
 
 	function addEnv(
 		env: Partial<Environment> = { name: `${data.name}.env.${Object.keys(data.localEnvironments).length}` },
@@ -45,23 +42,35 @@ export function EnvironmentsSection({ data, onChange }: SectionProps) {
 		setVisibleEnvId(newEnv.id);
 	}
 
-	function deleteEnv() {
-		if (envToDelete) {
-			const newData = structuredClone(localEnvs);
-			delete newData[envToDelete];
-			onChange({
-				localEnvironments: newData,
-			});
-		}
+	function deleteEnv(id: string) {
+		const newData = structuredClone(localEnvs);
+		delete newData[id];
+		onChange({
+			localEnvironments: newData,
+		});
 	}
 
-	const envList = Object.values(data.localEnvironments);
-	const visibleEnv = visibleEnvId == null ? null : data.localEnvironments[visibleEnvId];
-
 	return (
-		<Box>
-			<Stack direction="row" gap={1}>
-				<Select placeholder="Choose Environment" value={visibleEnvId} onChange={(_, value) => setVisibleEnvId(value)}>
+		<Stack>
+			<Box alignSelf="end" height={0}>
+				<SprocketTooltip text={`${data.linkedEnvMode ? 'Disable' : 'Enable'} Environment Linking`}>
+					<IconButton onClick={() => onChange({ linkedEnvMode: !data.linkedEnvMode })}>
+						{data.linkedEnvMode ? <LinkOff /> : <Link />}
+					</IconButton>
+				</SprocketTooltip>
+			</Box>
+			<Box height={data.linkedEnvMode ? 'fit-content' : 0} sx={{ transition: 'all 1s linear', overflow: 'hidden' }}>
+				<Box height="20px" />
+				<LinkedEnvironmentEditor service={data} />
+				<Divider sx={{ margin: '30px' }} />
+			</Box>
+			<Stack direction="row" gap={1} alignItems="center">
+				<Select
+					startDecorator={<ModeEdit />}
+					placeholder="Choose Environment"
+					value={visibleEnvId}
+					onChange={(_, value) => setVisibleEnvId(value)}
+				>
 					{envList.map((env) => (
 						<Option value={env.id} key={env.id}>
 							{env.name}
@@ -74,65 +83,28 @@ export function EnvironmentsSection({ data, onChange }: SectionProps) {
 					</IconButton>
 				</SprocketTooltip>
 			</Stack>
-			{visibleEnv != null && (
-				<EditableData
-					actions={{
-						middle: (
-							<EditableText
-								text={visibleEnv.name}
-								setText={(name) => modifyEnv(visibleEnv.id, { name })}
-								isValidFunc={function (text: string): boolean {
-									return text != '';
-								}}
-								color={data.selectedEnvironment === visibleEnv.id ? 'primary' : 'neutral'}
-							/>
-						),
-						start: (
-							<>
-								<SprocketTooltip text={data.selectedEnvironment === visibleEnv.id ? 'Unselect' : 'Select'}>
-									<IconButton
-										onClick={() => {
-											onChange({
-												selectedEnvironment: data.selectedEnvironment === visibleEnv.id ? undefined : visibleEnv.id,
-											});
-										}}
-									>
-										{data.selectedEnvironment === visibleEnv.id ? (
-											<RadioButtonCheckedIcon />
-										) : (
-											<RadioButtonUncheckedIcon />
-										)}
-									</IconButton>
-								</SprocketTooltip>
-								<SprocketTooltip text="Duplicate">
-									<IconButton onClick={() => addEnv(visibleEnv, ' (Copy)')}>
-										<FileCopyIcon />
-									</IconButton>
-								</SprocketTooltip>
-								<SprocketTooltip text="Delete">
-									<IconButton onClick={() => setEnvToDelete(visibleEnv.id)}>
-										<DeleteIcon />
-									</IconButton>
-								</SprocketTooltip>
-								<SprocketTooltip text="Link with Global Environment">
-									<IconButton>
-										<Link />
-									</IconButton>
-								</SprocketTooltip>
-							</>
-						),
-					}}
-					values={visibleEnv.pairs}
-					onChange={(pairs) => modifyEnv(visibleEnv.id, { pairs })}
-					envPairs={envPairs}
-				/>
-			)}
-			<AreYouSureModal
-				open={!!envToDelete}
-				closeFunc={() => setEnvToDelete(null)}
-				action={`delete ${data.localEnvironments[envToDelete ?? '']?.name ?? envToDelete}`}
-				actionFunc={deleteEnv}
-			></AreYouSureModal>
-		</Box>
+			<Stack width="100%" minWidth="500px" flex={1}>
+				{visibleEnv != null && (
+					<EnvironmentEditor
+						serviceId={data.id}
+						env={visibleEnv}
+						envPairs={envPairs}
+						onChange={(values) =>
+							onChange({
+								localEnvironments: { ...localEnvs, [visibleEnv.id]: { ...localEnvs[visibleEnv.id], ...values } },
+							})
+						}
+						onDelete={() => deleteEnv(visibleEnv.id)}
+						onClone={(env) => addEnv(env, ' (Copy)')}
+						selected={isVisibleSelected}
+						toggleSelected={
+							data.linkedEnvMode
+								? null
+								: () => onChange({ selectedEnvironment: isVisibleSelected ? undefined : visibleEnv.id })
+						}
+					/>
+				)}
+			</Stack>
+		</Stack>
 	);
 }

--- a/src/components/panels/service/EnvironmentsSection.tsx
+++ b/src/components/panels/service/EnvironmentsSection.tsx
@@ -36,6 +36,7 @@ export function EnvironmentsSection({ data, onChange }: SectionProps) {
 		const newEnv = cloneEnv(env, nameMod);
 		onChange({
 			localEnvironments: {
+				...localEnvs,
 				[newEnv.id]: newEnv,
 			},
 		});

--- a/src/components/panels/service/EnvironmentsSection.tsx
+++ b/src/components/panels/service/EnvironmentsSection.tsx
@@ -1,9 +1,6 @@
 import { useState } from 'react';
 import { IconButton, Select, Stack, Option, Box, Divider } from '@mui/joy';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
-import { useSelector } from 'react-redux';
-import { EnvironmentContextResolver } from '../../../managers/EnvironmentContextResolver';
-import { selectEnvironments, selectSecrets, selectSelectedEnvironmentValue } from '../../../state/active/selectors';
 import { SprocketTooltip } from '../../shared/SprocketTooltip';
 import { SectionProps } from './sectionProps';
 import { Environment } from '../../../types/application-data/application-data';
@@ -11,22 +8,16 @@ import { cloneEnv } from '../../../utils/application';
 import { EnvironmentEditor } from './EnvironmentEditor';
 import { Link, LinkOff, ModeEdit } from '@mui/icons-material';
 import { LinkedEnvironmentEditor } from './LinkedEnvironmentEditor';
+import { useComputedRootEnvironment } from '../../../hooks/useComputedEnvironment';
 
 export function EnvironmentsSection({ data, onChange }: SectionProps) {
 	const [visibleEnvId, setVisibleEnvId] = useState<string | null>(data.selectedEnvironment ?? null);
-	const secrets = useSelector(selectSecrets);
-	const rootEnv = useSelector(selectSelectedEnvironmentValue);
 	const localEnvs = data.localEnvironments;
 	const envList = Object.values(localEnvs);
 	const visibleEnv = visibleEnvId == null ? null : data.localEnvironments[visibleEnvId];
 	const isVisibleSelected = data.selectedEnvironment === visibleEnvId;
-	const environments = useSelector(selectEnvironments);
 
-	const envPairs = EnvironmentContextResolver.buildEnvironmentVariables({
-		rootEnv,
-		secrets,
-		rootAncestors: Object.values(environments),
-	}).toArray();
+	const envPairs = useComputedRootEnvironment();
 
 	function addEnv(
 		env: Partial<Environment> = { name: `${data.name}.env.${Object.keys(data.localEnvironments).length}` },

--- a/src/components/panels/service/GeneralSection.tsx
+++ b/src/components/panels/service/GeneralSection.tsx
@@ -1,0 +1,28 @@
+import { Box, Divider, Stack, Typography } from '@mui/joy';
+import { EditableTextArea } from '../../shared/input/EditableTextArea';
+import { InformationSection } from './InformationSection';
+import { RecentRequestsSection } from './RecentRequestsSection';
+import { SectionProps } from './sectionProps';
+
+export function GeneralSection({ data, onChange }: SectionProps) {
+	return (
+		<Stack gap={3} divider={<Divider />}>
+			<Stack direction="row" gap={3} width="100%" justifyContent="stretch" flexWrap="wrap">
+				<Box width="50%" minWidth="400px" flex={1}>
+					<EditableTextArea
+						text={data.description}
+						setText={(newText: string) => onChange({ description: newText })}
+						isValidFunc={(text: string) => text.length >= 1}
+					/>
+				</Box>
+				<Box width="50%" minWidth="400px" flex={1}>
+					<InformationSection data={data} onChange={onChange} />
+				</Box>
+			</Stack>
+			<Stack gap={2}>
+				<Typography level="h4">Recent Requests</Typography>
+				<RecentRequestsSection data={data} />
+			</Stack>
+		</Stack>
+	);
+}

--- a/src/components/panels/service/InformationSection.tsx
+++ b/src/components/panels/service/InformationSection.tsx
@@ -1,20 +1,23 @@
-import { Typography } from '@mui/joy';
+import { Select, Stack, Typography, Option } from '@mui/joy';
 import Table from '@mui/joy/Table';
-
 import { Service } from '../../../types/application-data/application-data';
 import { camelCaseToTitle } from '../../../utils/string';
 import { EditableText } from '../../shared/input/EditableText';
 import { SectionProps } from './sectionProps';
+import { Link } from '@mui/icons-material';
+import { SprocketTooltip } from '../../shared/SprocketTooltip';
 
 const serviceDataKeys = ['version', 'baseUrl'] as const satisfies readonly (keyof Service)[];
 
 export function InformationSection({ data, onChange }: SectionProps) {
+	const activeEnv = data.selectedEnvironment == null ? null : data.localEnvironments[data.selectedEnvironment];
+	const envList = Object.values(data.localEnvironments);
 	return (
-		<Table variant="outlined" borderAxis={'bothBetween'} sx={{ maxWidth: '70%', ml: 'auto', mr: 'auto' }}>
+		<Table variant="outlined" borderAxis={'bothBetween'}>
 			<tbody>
 				{serviceDataKeys.map((serviceDataKey, index) => (
 					<tr key={index}>
-						<td>
+						<td width="150px">
 							<Typography level="body-md">{camelCaseToTitle(serviceDataKey)}</Typography>
 						</td>
 						<td>
@@ -26,6 +29,33 @@ export function InformationSection({ data, onChange }: SectionProps) {
 						</td>
 					</tr>
 				))}
+				<tr>
+					<td width="150px">
+						<Typography level="body-md">Active Environment</Typography>
+					</td>
+					<td>
+						{data.linkedEnvMode ? (
+							<Stack direction="row" gap={1} ml="3px">
+								<SprocketTooltip text="Linked Environment">
+									<Link />
+								</SprocketTooltip>
+								<Typography>{activeEnv?.name ?? 'None'}</Typography>
+							</Stack>
+						) : (
+							<Select
+								placeholder="None"
+								value={activeEnv?.id ?? null}
+								onChange={(_, value) => onChange({ selectedEnvironment: value ?? undefined })}
+							>
+								{envList.map((env) => (
+									<Option value={env.id} key={env.id}>
+										{env.name}
+									</Option>
+								))}
+							</Select>
+						)}
+					</td>
+				</tr>
 			</tbody>
 		</Table>
 	);

--- a/src/components/panels/service/LinkedEnvironmentEditor.tsx
+++ b/src/components/panels/service/LinkedEnvironmentEditor.tsx
@@ -1,0 +1,45 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { selectEnvironments } from '../../../state/active/selectors';
+import { useMemo } from 'react';
+import { Service } from '../../../types/application-data/application-data';
+import { Select, Stack, Option } from '@mui/joy';
+import { addLinkedEnv } from '../../../state/active/slice';
+import { Link } from '@mui/icons-material';
+import { EllipsisTypography } from '../../shared/EllipsisTypography';
+
+interface LinkedEnvironmentEditorProps {
+	service: Service;
+}
+
+export function LinkedEnvironmentEditor({ service }: LinkedEnvironmentEditorProps) {
+	const environments = useSelector(selectEnvironments);
+	const dispatch = useDispatch();
+	const envList = useMemo(
+		() =>
+			Object.values(environments).map((env) => ({ name: env.name, id: env.id, linkedEnv: env.linked?.[service.id] })),
+		[environments],
+	);
+	return (
+		<Stack gap={2}>
+			{envList.map((env) => (
+				<Stack key={env.id} gap={1}>
+					<EllipsisTypography>{env.name}</EllipsisTypography>
+					<Select
+						startDecorator={<Link />}
+						placeholder="None"
+						value={env.linkedEnv}
+						onChange={(_, value) =>
+							dispatch(addLinkedEnv({ serviceEnvId: value, serviceId: service.id, envId: env.id }))
+						}
+					>
+						{Object.values(service.localEnvironments).map((localEnv) => (
+							<Option value={localEnv.id} key={localEnv.id}>
+								{localEnv.name}
+							</Option>
+						))}
+					</Select>
+				</Stack>
+			))}
+		</Stack>
+	);
+}

--- a/src/components/panels/service/RecentRequestListItem.tsx
+++ b/src/components/panels/service/RecentRequestListItem.tsx
@@ -1,13 +1,4 @@
-import {
-	Box,
-	IconButton,
-	ListDivider,
-	ListItem,
-	ListItemContent,
-	ListItemDecorator,
-	Stack,
-	Typography,
-} from '@mui/joy';
+import { Box, IconButton, ListItem, ListItemContent, ListItemDecorator, Stack, Typography } from '@mui/joy';
 import EventIcon from '@mui/icons-material/Event';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { useAppDispatch } from '../../../state/store';
@@ -52,7 +43,6 @@ export function RecentRequestListItem({ request }: RecentRequestListItemProps) {
 					</Stack>
 				</ListItemContent>
 			</ListItem>
-			<ListDivider inset="gutter" />
 		</>
 	);
 }

--- a/src/components/panels/service/ServicePanel.tsx
+++ b/src/components/panels/service/ServicePanel.tsx
@@ -1,17 +1,15 @@
-import { Accordion, AccordionDetails, AccordionGroup, AccordionSummary } from '@mui/joy';
-
 import { useSelector } from 'react-redux';
 import { selectServices } from '../../../state/active/selectors';
 import { updateService } from '../../../state/active/slice';
 import { useAppDispatch } from '../../../state/store';
 import { Service } from '../../../types/application-data/application-data';
 import { EditableText } from '../../shared/input/EditableText';
-import { EditableTextArea } from '../../shared/input/EditableTextArea';
 import { PanelProps } from '../panels.interface';
 import { PrePostScriptDisplay } from '../shared/PrePostScriptDisplay';
-import { InformationSection } from './InformationSection';
 import { EnvironmentsSection } from './EnvironmentsSection';
-import { RecentRequestsSection } from './RecentRequestsSection';
+import { SprocketTabs } from '../../shared/SprocketTabs';
+import { AccordionGroup } from '@mui/joy';
+import { GeneralSection } from './GeneralSection';
 
 export function ServicePanel({ id }: PanelProps) {
 	const dispatch = useAppDispatch();
@@ -23,7 +21,7 @@ export function ServicePanel({ id }: PanelProps) {
 	}
 
 	return (
-		<div>
+		<>
 			<EditableText
 				sx={{ margin: 'auto' }}
 				text={serviceData.name}
@@ -31,44 +29,30 @@ export function ServicePanel({ id }: PanelProps) {
 				isValidFunc={(text: string) => text.length >= 1}
 				level="h2"
 			/>
-			<AccordionGroup transition="0.2s ease">
-				<Accordion defaultExpanded={true}>
-					<AccordionSummary>Description</AccordionSummary>
-					<AccordionDetails>
-						<EditableTextArea
-							label="Description"
-							text={serviceData.description}
-							setText={(newText: string) => update({ description: newText })}
-							isValidFunc={(text: string) => text.length >= 1}
-							renderAsMarkdown={true}
-						/>
-					</AccordionDetails>
-				</Accordion>
-
-				<Accordion defaultExpanded={true}>
-					<AccordionSummary>Information</AccordionSummary>
-					<AccordionDetails>
-						<InformationSection data={serviceData} onChange={update} />
-					</AccordionDetails>
-				</Accordion>
-				<Accordion defaultExpanded={true}>
-					<AccordionSummary>Environments</AccordionSummary>
-					<AccordionDetails>
-						<EnvironmentsSection data={serviceData} onChange={update} />
-					</AccordionDetails>
-				</Accordion>
-				<PrePostScriptDisplay
-					onChange={update}
-					preRequestScript={serviceData.preRequestScript}
-					postRequestScript={serviceData.postRequestScript}
-				/>
-				<Accordion defaultExpanded>
-					<AccordionSummary>Recent Requests</AccordionSummary>
-					<AccordionDetails>
-						<RecentRequestsSection data={serviceData} />
-					</AccordionDetails>
-				</Accordion>
-			</AccordionGroup>
-		</div>
+			<SprocketTabs
+				tabs={[
+					{
+						title: 'General',
+						content: <GeneralSection data={serviceData} onChange={update} />,
+					},
+					{
+						title: 'Environments',
+						content: <EnvironmentsSection data={serviceData} onChange={update} />,
+					},
+					{
+						title: 'Scripts',
+						content: (
+							<AccordionGroup transition="0.2s ease">
+								<PrePostScriptDisplay
+									onChange={update}
+									preRequestScript={serviceData.preRequestScript}
+									postRequestScript={serviceData.postRequestScript}
+								/>
+							</AccordionGroup>
+						),
+					},
+				]}
+			/>
+		</>
 	);
 }

--- a/src/components/panels/service/ServicePanel.tsx
+++ b/src/components/panels/service/ServicePanel.tsx
@@ -1,4 +1,4 @@
-import { Accordion, AccordionDetails, AccordionGroup, AccordionSummary, Stack } from '@mui/joy';
+import { Accordion, AccordionDetails, AccordionGroup, AccordionSummary } from '@mui/joy';
 
 import { useSelector } from 'react-redux';
 import { selectServices } from '../../../state/active/selectors';
@@ -24,52 +24,51 @@ export function ServicePanel({ id }: PanelProps) {
 
 	return (
 		<div>
-			<Stack direction={'column'}>
-				<EditableText
-					text={serviceData.name}
-					setText={(newText: string) => update({ name: newText })}
-					isValidFunc={(text: string) => text.length >= 1}
-					isTitle
-				/>
-				<AccordionGroup transition="0.2s ease">
-					<Accordion defaultExpanded={true}>
-						<AccordionSummary>Description</AccordionSummary>
-						<AccordionDetails>
-							<EditableTextArea
-								label="Description"
-								text={serviceData.description}
-								setText={(newText: string) => update({ description: newText })}
-								isValidFunc={(text: string) => text.length >= 1}
-								renderAsMarkdown={true}
-							/>
-						</AccordionDetails>
-					</Accordion>
+			<EditableText
+				sx={{ margin: 'auto' }}
+				text={serviceData.name}
+				setText={(newText: string) => update({ name: newText })}
+				isValidFunc={(text: string) => text.length >= 1}
+				level="h2"
+			/>
+			<AccordionGroup transition="0.2s ease">
+				<Accordion defaultExpanded={true}>
+					<AccordionSummary>Description</AccordionSummary>
+					<AccordionDetails>
+						<EditableTextArea
+							label="Description"
+							text={serviceData.description}
+							setText={(newText: string) => update({ description: newText })}
+							isValidFunc={(text: string) => text.length >= 1}
+							renderAsMarkdown={true}
+						/>
+					</AccordionDetails>
+				</Accordion>
 
-					<Accordion defaultExpanded={true}>
-						<AccordionSummary>Information</AccordionSummary>
-						<AccordionDetails>
-							<InformationSection data={serviceData} onChange={update} />
-						</AccordionDetails>
-					</Accordion>
-					<Accordion defaultExpanded={true}>
-						<AccordionSummary>Environments</AccordionSummary>
-						<AccordionDetails>
-							<EnvironmentsSection data={serviceData} onChange={update} />
-						</AccordionDetails>
-					</Accordion>
-					<PrePostScriptDisplay
-						onChange={update}
-						preRequestScript={serviceData.preRequestScript}
-						postRequestScript={serviceData.postRequestScript}
-					/>
-					<Accordion defaultExpanded>
-						<AccordionSummary>Recent Requests</AccordionSummary>
-						<AccordionDetails>
-							<RecentRequestsSection data={serviceData} />
-						</AccordionDetails>
-					</Accordion>
-				</AccordionGroup>
-			</Stack>
+				<Accordion defaultExpanded={true}>
+					<AccordionSummary>Information</AccordionSummary>
+					<AccordionDetails>
+						<InformationSection data={serviceData} onChange={update} />
+					</AccordionDetails>
+				</Accordion>
+				<Accordion defaultExpanded={true}>
+					<AccordionSummary>Environments</AccordionSummary>
+					<AccordionDetails>
+						<EnvironmentsSection data={serviceData} onChange={update} />
+					</AccordionDetails>
+				</Accordion>
+				<PrePostScriptDisplay
+					onChange={update}
+					preRequestScript={serviceData.preRequestScript}
+					postRequestScript={serviceData.postRequestScript}
+				/>
+				<Accordion defaultExpanded>
+					<AccordionSummary>Recent Requests</AccordionSummary>
+					<AccordionDetails>
+						<RecentRequestsSection data={serviceData} />
+					</AccordionDetails>
+				</Accordion>
+			</AccordionGroup>
 		</div>
 	);
 }

--- a/src/components/root/modals/createModals/CreateServiceModal.tsx
+++ b/src/components/root/modals/createModals/CreateServiceModal.tsx
@@ -12,10 +12,10 @@ import {
 	Textarea,
 } from '@mui/joy';
 import { CreateModalsProps } from './createModalsProps';
-import { iconFromTabType, Service } from '../../../../types/application-data/application-data';
+import { iconFromTabType } from '../../../../types/application-data/application-data';
 import { useState } from 'react';
 import { useAppDispatch } from '../../../../state/store';
-import { cloneService } from '../../../../state/active/thunks/services';
+import { addNewService } from '../../../../state/active/thunks/services';
 import { tabsActions } from '../../../../state/tabs/slice';
 
 export function CreateServiceModal({ open, closeFunc }: CreateModalsProps) {
@@ -27,14 +27,9 @@ export function CreateServiceModal({ open, closeFunc }: CreateModalsProps) {
 	const allFieldsValid = serviceNameValid;
 
 	const createServiceFunction = async () => {
-		const newService: Partial<Service> = { name: serviceName };
-		if (serviceDescription) {
-			newService.description = serviceDescription;
-		}
-		if (baseUrl) {
-			newService.baseUrl = baseUrl;
-		}
-		const createdServiceId = await dispatch(cloneService({ data: newService })).unwrap();
+		const createdServiceId = await dispatch(
+			addNewService({ name: serviceName, description: serviceDescription, baseUrl }),
+		).unwrap();
 		dispatch(tabsActions.addTabs({ [createdServiceId]: 'service' }));
 		dispatch(tabsActions.setSelectedTab(createdServiceId));
 	};

--- a/src/components/root/overlays/ResponseDiffOverlay/ResponseDiffOverlay.tsx
+++ b/src/components/root/overlays/ResponseDiffOverlay/ResponseDiffOverlay.tsx
@@ -16,20 +16,23 @@ import {
 } from '@mui/joy';
 import { useState } from 'react';
 import { HistoryControl } from '../../../panels/request/response/HistoryControl';
-import { SprocketEditor } from '../../../shared/input/SprocketEditor';
 import { VisualEventLog } from '../../../panels/request/response/VisualEventLog';
 import { formatShortFullDate } from '../../../../utils/string';
 import { SearchableRequestDropdown } from './SearchableRequestDropdown';
 import { statusCodes } from '../../../../constants/statusCodes';
 import { verbColors } from '../../../../constants/style';
+import { KeyValuePair } from '../../../../classes/OrderedKeyValuePairs';
+import { toKeyValuePairs } from '../../../../utils/application';
+import { DiffText } from '../../../shared/input/DiffText';
 
-function headersToJson(headers: Record<string, string>) {
+function headersToJson(headers: Record<string, string> | KeyValuePair[]) {
+	const convertedHeaders = Array.isArray(headers) ? headers.slice() : toKeyValuePairs(headers);
 	return JSON.stringify(
-		Object.entries(headers)
-			.sort((e1, e2) => e1[0].localeCompare(e2[0]))
+		convertedHeaders
+			.sort((e1, e2) => e1.key.localeCompare(e2.key))
 			.reduce(
 				(acc, curr) => {
-					acc[curr[0]] = curr[1];
+					acc[curr.key] = curr.value ?? '';
 					return acc;
 				},
 				{} as Record<string, string>,
@@ -200,15 +203,11 @@ export function ResponseDiffOverlay({ initialSelection }: ResponseDiffOverlayPro
 									<Typography sx={{ textAlign: 'center', mt: '20px' }} level="h4">
 										Response Body
 									</Typography>
-									<SprocketEditor
-										width={'100%'}
-										height={'40vh'}
-										isDiff={true}
+									<DiffText
 										original={original.response.body}
 										modified={modified.response.body}
 										originalLanguage={original.response.bodyType?.toLocaleLowerCase()}
 										modifiedLanguage={modified.response.bodyType?.toLocaleLowerCase()}
-										options={{ readOnly: true, domReadOnly: true, originalEditable: false }}
 									/>
 								</>
 							</TabPanel>
@@ -225,14 +224,9 @@ export function ResponseDiffOverlay({ initialSelection }: ResponseDiffOverlayPro
 											{modified.response.statusCode}: {statusCodes[modified.response.statusCode]}
 										</Typography>
 									</Stack>
-									<SprocketEditor
-										width={'100%'}
-										height={'40vh'}
-										isDiff={true}
+									<DiffText
 										original={headersToJson(original.response.headers)}
 										modified={headersToJson(modified.response.headers)}
-										language="json"
-										options={{ readOnly: true, domReadOnly: true, originalEditable: false }}
 									/>
 								</>
 							</TabPanel>
@@ -241,14 +235,9 @@ export function ResponseDiffOverlay({ initialSelection }: ResponseDiffOverlayPro
 									<Typography sx={{ textAlign: 'center', mt: '20px' }} level="h4">
 										Request Headers
 									</Typography>
-									<SprocketEditor
-										width={'100%'}
-										height={'40vh'}
-										isDiff={true}
-										original={original.request.headers.toJSON()}
-										modified={modified.request.headers.toJSON()}
-										language="json"
-										options={{ readOnly: true, domReadOnly: true, originalEditable: false }}
+									<DiffText
+										original={headersToJson(original.request.headers)}
+										modified={headersToJson(modified.request.headers)}
 									/>
 								</>
 							</TabPanel>
@@ -271,15 +260,11 @@ export function ResponseDiffOverlay({ initialSelection }: ResponseDiffOverlayPro
 											</Stack>
 										</Box>
 									</Stack>
-									<SprocketEditor
-										width={'100%'}
-										height={'40vh'}
-										isDiff={true}
+									<DiffText
 										original={original.request.body}
 										modified={modified.request.body}
 										originalLanguage={original.request.bodyType?.toLocaleLowerCase()}
 										modifiedLanguage={modified.request.bodyType?.toLocaleLowerCase()}
-										options={{ readOnly: true, domReadOnly: true, originalEditable: false }}
 									/>
 								</>
 							</TabPanel>

--- a/src/components/root/overlays/ResponseDiffOverlay/ResponseDiffOverlay.tsx
+++ b/src/components/root/overlays/ResponseDiffOverlay/ResponseDiffOverlay.tsx
@@ -103,7 +103,7 @@ export function ResponseDiffOverlay({ initialSelection }: ResponseDiffOverlayPro
 			</Typography>
 			<Divider />
 			<Stack>
-				<Stack direction={'row'} spacing={2} sx={{ mt: '20px' }} justifyContent={'space-between'}>
+				<Stack direction="row" spacing={2} sx={{ mt: '20px' }} justifyContent={'space-between'}>
 					{(['left', 'right'] as const).map((direction) => (
 						<Box key={direction}>
 							<Stack direction={'column'}>
@@ -164,7 +164,7 @@ export function ResponseDiffOverlay({ initialSelection }: ResponseDiffOverlayPro
 
 								<FormControl>
 									<FormLabel>History Item</FormLabel>
-									<Stack direction={'row'} alignItems={'center'}>
+									<Stack direction="row" alignItems={'center'}>
 										<HistoryControl
 											value={selectedHistoryIndex[direction] ?? 0}
 											historyLength={selectedRequest[direction]?.history.length ?? 0}
@@ -216,7 +216,7 @@ export function ResponseDiffOverlay({ initialSelection }: ResponseDiffOverlayPro
 									<Typography sx={{ textAlign: 'center', mt: '20px' }} level="h4">
 										Response Headers
 									</Typography>
-									<Stack direction={'row'} justifyContent={'space-between'}>
+									<Stack direction="row" justifyContent={'space-between'}>
 										<Typography>
 											{original.response.statusCode}: {statusCodes[original.response.statusCode]}
 										</Typography>
@@ -246,15 +246,15 @@ export function ResponseDiffOverlay({ initialSelection }: ResponseDiffOverlayPro
 									<Typography sx={{ textAlign: 'center', mt: '20px' }} level="h4">
 										Request Body
 									</Typography>
-									<Stack direction={'row'} justifyContent={'space-between'} textAlign={'center'}>
+									<Stack direction="row" justifyContent={'space-between'} textAlign={'center'}>
 										<Box>
-											<Stack direction={'row'} spacing={0}>
+											<Stack direction="row" spacing={0}>
 												<Chip color={verbColors[original.request.method]}>{original.request.method}</Chip>
 												<Typography level="body-md">{original.request.url}</Typography>
 											</Stack>
 										</Box>
 										<Box>
-											<Stack direction={'row'} spacing={0}>
+											<Stack direction="row" spacing={0}>
 												<Chip color={verbColors[modified.request.method]}>{modified.request.method}</Chip>
 												<Typography level="body-md">{modified.request.url}</Typography>
 											</Stack>
@@ -272,7 +272,7 @@ export function ResponseDiffOverlay({ initialSelection }: ResponseDiffOverlayPro
 								<Typography sx={{ textAlign: 'center', mt: '20px' }} level="h4">
 									Event Log
 								</Typography>
-								<Stack direction={'row'} justifyContent={'space-between'}>
+								<Stack direction="row" justifyContent={'space-between'}>
 									<VisualEventLog auditLog={original.auditLog ?? []} requestId={selectedRequest.left.id} />
 									<VisualEventLog auditLog={modified.auditLog ?? []} requestId={selectedRequest.right.id} />
 								</Stack>

--- a/src/components/shared/EllipsisTypography.tsx
+++ b/src/components/shared/EllipsisTypography.tsx
@@ -26,14 +26,13 @@ export function EllipsisTypography({ sx, children, ...props }: TypographyProps) 
 			sx={{
 				flex: 1,
 				maxWidth: '100%',
-				width: '100%',
+				width: 'fit-content',
 				textOverflow: 'ellipsis',
 				textWrap: 'nowrap',
 				whiteSpace: 'nowrap',
 				overflow: 'hidden',
 				...sx,
 			}}
-			fontSize="sm"
 		>
 			{children}
 		</Typography>

--- a/src/components/shared/SprocketTabs.tsx
+++ b/src/components/shared/SprocketTabs.tsx
@@ -1,0 +1,31 @@
+import { Tab, TabList, TabPanel, Tabs } from '@mui/joy';
+import { useState } from 'react';
+
+interface SprocketTab {
+	content: React.ReactNode;
+	title: string;
+}
+
+interface SprocketTabsProps {
+	tabs: SprocketTab[];
+}
+
+export function SprocketTabs({ tabs }: SprocketTabsProps) {
+	const [tab, setTab] = useState(0);
+	return (
+		<Tabs aria-label="tabs" size="lg" value={tab} onChange={(_event, newValue) => setTab((newValue ?? 0) as number)}>
+			<TabList color="primary">
+				{tabs.map(({ title }, index) => (
+					<Tab color={index === tab ? 'primary' : 'neutral'} value={index} key={index}>
+						{title}
+					</Tab>
+				))}
+			</TabList>
+			{tabs.map((tab, index) => (
+				<TabPanel key={index} value={index}>
+					{tab.content}
+				</TabPanel>
+			))}
+		</Tabs>
+	);
+}

--- a/src/components/shared/UriTypography.tsx
+++ b/src/components/shared/UriTypography.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren } from 'react';
 export function UriTypography({ children }: PropsWithChildren) {
 	return (
 		<u>
-			<span style={{ overflowWrap: 'break-word' }}>{children}</span>
+			<span style={{ overflowWrap: 'anywhere', wordBreak: 'break-all' }}>{children}</span>
 		</u>
 	);
 }

--- a/src/components/shared/UriTypography.tsx
+++ b/src/components/shared/UriTypography.tsx
@@ -1,0 +1,9 @@
+import { PropsWithChildren } from 'react';
+
+export function UriTypography({ children }: PropsWithChildren) {
+	return (
+		<u>
+			<span style={{ overflowWrap: 'break-word' }}>{children}</span>
+		</u>
+	);
+}

--- a/src/components/shared/input/ActionBar.tsx
+++ b/src/components/shared/input/ActionBar.tsx
@@ -1,0 +1,25 @@
+import { Stack } from '@mui/joy';
+import { PropsWithChildren } from 'react';
+
+export interface ActionBarProps extends PropsWithChildren {
+	start?: React.ReactNode;
+	end?: React.ReactNode;
+}
+
+export type ActionBarPassthroughProps = Omit<ActionBarProps, 'children'> & { middle?: ActionBarProps['children'] };
+
+export function ActionBar({ start, children, end }: ActionBarProps) {
+	return (
+		<Stack direction="row" justifyContent="stretch" alignItems="end" flexWrap="nowrap" gap={2}>
+			<Stack direction="row" justifyContent="start" alignItems="end" width="25%">
+				{start}
+			</Stack>
+			<Stack direction="row" justifyContent="center" alignItems="end" minWidth="fit-content" width="100%">
+				{children}
+			</Stack>
+			<Stack direction="row" justifyContent="end" alignItems="end" width="25%">
+				{end}
+			</Stack>
+		</Stack>
+	);
+}

--- a/src/components/shared/input/ActionBar.tsx
+++ b/src/components/shared/input/ActionBar.tsx
@@ -11,13 +11,13 @@ export type ActionBarPassthroughProps = Omit<ActionBarProps, 'children'> & { mid
 export function ActionBar({ start, children, end }: ActionBarProps) {
 	return (
 		<Stack direction="row" justifyContent="stretch" alignItems="end" flexWrap="nowrap" gap={2}>
-			<Stack direction="row" justifyContent="start" alignItems="end" width="25%">
+			<Stack direction="row" justifyContent="start" alignItems="end" width="50%">
 				{start}
 			</Stack>
 			<Stack direction="row" justifyContent="center" alignItems="end" minWidth="fit-content" width="100%">
 				{children}
 			</Stack>
-			<Stack direction="row" justifyContent="end" alignItems="end" width="25%">
+			<Stack direction="row" justifyContent="end" alignItems="end" width="50%">
 				{end}
 			</Stack>
 		</Stack>

--- a/src/components/shared/input/DiffText.tsx
+++ b/src/components/shared/input/DiffText.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { DiffEditor, DiffEditorProps } from '@monaco-editor/react';
+import { defaultEditorOptions } from '../../../managers/MonacoInitManager';
+import { editor } from 'monaco-editor';
+import { useEditorTheme } from '../../../hooks/useEditorTheme';
+
+const diffOptions = { ...defaultEditorOptions, readOnly: true, domReadOnly: true, originalEditable: false };
+
+export function DiffText({ original, modified, options, width, height, language, ...props }: DiffEditorProps) {
+	const combinedOptions = { ...diffOptions, ...options };
+	const editorTheme = useEditorTheme();
+	const editorRef = useRef<editor.IStandaloneDiffEditor | null>(null);
+	const format = async () => {
+		if (editorRef.current != null) {
+			editorRef.current?.updateOptions({ ...combinedOptions, readOnly: false, originalEditable: true });
+			const formatFirst = editorRef.current.getOriginalEditor().getAction('editor.action.formatDocument')?.run();
+			const formatSecond = editorRef.current.getModifiedEditor().getAction('editor.action.formatDocument')?.run();
+			await Promise.all([formatFirst, formatSecond]);
+			editorRef.current?.updateOptions(combinedOptions);
+		}
+	};
+
+	useEffect(() => {
+		if (options != null) {
+			editorRef.current?.updateOptions(combinedOptions);
+		}
+	}, [combinedOptions]);
+
+	useEffect(() => {
+		format();
+	}, [original, modified]);
+
+	return (
+		<DiffEditor
+			language={language ?? 'json'}
+			theme={editorTheme}
+			options={combinedOptions}
+			onMount={(editor) => {
+				editorRef.current = editor;
+				format();
+			}}
+			original={original}
+			modified={modified}
+			width={width ?? '100%'}
+			height={height ?? '40vh'}
+			{...props}
+		/>
+	);
+}

--- a/src/components/shared/input/EditableData.tsx
+++ b/src/components/shared/input/EditableData.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, IconButton, Stack, useColorScheme } from '@mui/joy';
+import { Badge, Box, IconButton, Stack } from '@mui/joy';
 import { useState, useRef, useMemo, useEffect } from 'react';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import EditIcon from '@mui/icons-material/Edit';
@@ -13,9 +13,9 @@ import { editor } from 'monaco-editor';
 import { SprocketTooltip } from '../SprocketTooltip';
 import { CopyToClipboardButton } from '../buttons/CopyToClipboardButton';
 import { KeyValuePair, KeyValueValues } from '../../../classes/OrderedKeyValuePairs';
-import { getEditorTheme } from '../../../utils/style';
 import { replaceValuesByKey } from '../../../utils/variables';
 import { FormatButton } from '../buttons/FormatButton';
+import { useEditorTheme } from '../../../hooks/useEditorTheme';
 
 function parseEditorJSON<T>(text: string): Record<string, T> {
 	if (text === '') return {};
@@ -33,7 +33,7 @@ interface EditableDataProps<T extends KeyValueValues> extends EditableDataSettin
 }
 
 export function EditableData<T extends KeyValueValues>({ values, onChange, fullSize, envPairs }: EditableDataProps<T>) {
-	const theme = getEditorTheme(useColorScheme());
+	const theme = useEditorTheme();
 
 	const selectedEnvironment = useSelector(selectSelectedEnvironment);
 	const environments = useSelector(selectEnvironments);

--- a/src/components/shared/input/EditableText.tsx
+++ b/src/components/shared/input/EditableText.tsx
@@ -1,24 +1,19 @@
-import { IconButton, Input, Typography, TypographyProps } from '@mui/joy';
+import { Box, IconButton, Input, Stack, TypographyProps } from '@mui/joy';
 import { useEffect, useState } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import CancelIcon from '@mui/icons-material/Cancel';
 import ModeEditIcon from '@mui/icons-material/ModeEdit';
-import { keepStringLengthReasonable } from '../../../utils/string';
 import { SprocketTooltip } from '../SprocketTooltip';
-interface EditableTextProps {
+import { EllipsisTypography } from '../EllipsisTypography';
+
+interface EditableTextProps extends Partial<TypographyProps> {
 	text: string;
 	setText: (text: string) => void;
 	isValidFunc: (text: string) => boolean;
-	isTitle?: boolean;
+	narrow?: boolean;
 }
 
-export function EditableText({
-	text,
-	setText,
-	isValidFunc,
-	isTitle,
-	...props
-}: EditableTextProps & Partial<TypographyProps>) {
+export function EditableText({ text, setText, isValidFunc, sx, narrow = false, ...props }: EditableTextProps) {
 	const [isEditing, setIsEditing] = useState(false);
 	const [typingText, setTypingText] = useState(text);
 	const [isValid, setIsValid] = useState(true);
@@ -32,64 +27,70 @@ export function EditableText({
 			setIsEditing(false);
 		}
 	};
-	return isEditing ? (
-		<Input
-			size={isTitle ? 'lg' : 'md'}
-			sx={{
-				maxWidth: isTitle ? '100%' : '600px',
-				marginLeft: 'auto',
-				marginRight: 'auto',
-				width: isTitle ? '80%' : undefined,
-			}}
-			placeholder={isTitle ? `Enter your title here` : `${text}`}
-			variant="outlined"
-			value={typingText}
-			onChange={(e) => setTypingText(e.target.value)}
-			onKeyDown={(e) => {
-				if (e.key === 'Enter') {
-					commitInput();
-				}
-			}}
-			error={!isValid}
-			endDecorator={
-				<>
-					<SprocketTooltip text="Cancel">
-						<IconButton
-							onClick={() => {
-								setIsEditing(false);
-							}}
-							sx={{ marginRight: '2px' }}
-						>
-							<CancelIcon fontSize="large" />
-						</IconButton>
-					</SprocketTooltip>
-					<SprocketTooltip text="Save">
-						<IconButton
-							onClick={() => {
-								commitInput();
-							}}
-							disabled={!isValid}
-						>
-							<CheckIcon fontSize="large" />
-						</IconButton>
-					</SprocketTooltip>
-				</>
-			}
-		/>
-	) : (
-		<Typography
-			level={isTitle ? `h2` : 'body-md'}
-			sx={{ textAlign: 'center', ml: 'auto', mr: 'auto' }}
-			onClick={() => {
-				setTypingText(text);
-				setIsEditing(true);
-			}}
-			{...props}
+
+	const toggleEditing = () => {
+		if (isEditing) {
+			commitInput();
+		} else {
+			setTypingText(text);
+			setIsEditing(true);
+		}
+	};
+
+	return (
+		<Stack
+			direction="row"
+			maxWidth={narrow ? '100%' : 'calc(100% - 100px)'}
+			width="fit-content"
+			alignItems="center"
+			minHeight="2.5em"
+			sx={sx}
 		>
-			<SprocketTooltip text="Edit">
-				<ModeEditIcon sx={{ verticalAlign: 'middle', pr: '5px' }} />
+			<SprocketTooltip text={isEditing ? 'Save' : 'Edit'} sx={{ flexBasis: 0 }}>
+				<IconButton onClick={toggleEditing} disabled={isEditing && !isValid} size="sm">
+					{isEditing ? <CheckIcon /> : <ModeEditIcon />}
+				</IconButton>
 			</SprocketTooltip>
-			{keepStringLengthReasonable(text, isTitle ? 100 : 30)}
-		</Typography>
+			<Box position="relative" flexGrow={1} width="100%" minWidth={0}>
+				{isEditing && (
+					<Input
+						autoFocus
+						sx={{
+							zIndex: 100,
+							position: 'absolute',
+							left: 0,
+							width: 'calc(100% + 50px)',
+							minWidth: narrow ? 0 : '200px',
+							height: '100%',
+							'--Input-minHeight': '1.5em',
+							'--Input-gap': 2,
+						}}
+						variant="soft"
+						placeholder={text}
+						value={typingText}
+						onChange={(e) => setTypingText(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter') {
+								commitInput();
+							}
+						}}
+						error={!isValid}
+						endDecorator={
+							<SprocketTooltip text="Cancel">
+								<IconButton
+									onClick={() => {
+										setIsEditing(false);
+									}}
+									size="sm"
+								>
+									<CancelIcon />
+								</IconButton>
+							</SprocketTooltip>
+						}
+					/>
+				)}
+				<EllipsisTypography {...props}>{text}</EllipsisTypography>
+			</Box>
+		</Stack>
 	);
 }

--- a/src/components/shared/input/EditableText.tsx
+++ b/src/components/shared/input/EditableText.tsx
@@ -16,10 +16,8 @@ interface EditableTextProps extends Partial<TypographyProps> {
 export function EditableText({ text, setText, isValidFunc, sx, narrow = false, ...props }: EditableTextProps) {
 	const [isEditing, setIsEditing] = useState(false);
 	const [typingText, setTypingText] = useState(text);
-	const [isValid, setIsValid] = useState(true);
-	useEffect(() => {
-		setIsValid(isValidFunc(typingText));
-	}, [typingText, isValidFunc]);
+
+	const isValid = isValidFunc(text);
 
 	const commitInput = () => {
 		if (isValid) {
@@ -36,6 +34,11 @@ export function EditableText({ text, setText, isValidFunc, sx, narrow = false, .
 			setIsEditing(true);
 		}
 	};
+
+	useEffect(() => {
+		setTypingText(text);
+		setIsEditing(false);
+	}, [text]);
 
 	return (
 		<Stack

--- a/src/components/shared/input/EditableTextArea.tsx
+++ b/src/components/shared/input/EditableTextArea.tsx
@@ -1,73 +1,69 @@
-import { IconButton, Typography } from '@mui/joy';
+import { Box, IconButton, Stack, Textarea } from '@mui/joy';
 import { useEffect, useState } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import CancelIcon from '@mui/icons-material/Cancel';
 import Markdown from 'react-markdown';
-import { FloatingLabelTextArea } from './FloatingLabelTextArea';
+import { SprocketTooltip } from '../SprocketTooltip';
+import { ModeEdit } from '@mui/icons-material';
 
 interface EditableTextAreaProps {
 	text: string;
 	setText: (text: string) => void;
 	isValidFunc: (text: string) => boolean;
-	label: string;
-	renderAsMarkdown?: boolean;
 }
 
-export function EditableTextArea(props: EditableTextAreaProps) {
+export function EditableTextArea({ text, setText, isValidFunc }: EditableTextAreaProps) {
 	const [isEditing, setIsEditing] = useState(false);
-	const [typingText, setTypingText] = useState(props.text);
-	const [isValid, setIsValid] = useState(true);
+	const [typingText, setTypingText] = useState(text);
+
+	const isValid = isValidFunc(typingText);
+
+	function toggleEditing() {
+		if (isEditing) {
+			if (isValid) {
+				setText(typingText);
+				setIsEditing(false);
+			}
+		} else {
+			setTypingText(text);
+			setIsEditing(true);
+		}
+	}
+
 	useEffect(() => {
-		setIsValid(props.isValidFunc(typingText));
-	}, [typingText, props.isValidFunc]);
-	const decorator = (
-		<div style={{ marginLeft: 'auto' }}>
-			<IconButton
-				onClick={() => {
-					setIsEditing(false);
-				}}
-				sx={{ marginRight: '2px' }}
-			>
-				<CancelIcon fontSize="large" />
-			</IconButton>
-			<IconButton
-				onClick={() => {
-					if (isValid) {
-						props.setText(typingText);
-						setIsEditing(false);
-					}
-				}}
-				disabled={!isValid}
-			>
-				<CheckIcon fontSize="large" />
-			</IconButton>
-		</div>
-	);
-	return isEditing ? (
-		<FloatingLabelTextArea
-			size={'md'}
-			label={props.label}
-			variant="outlined"
-			value={typingText}
-			onChange={(e) => setTypingText(e.target.value)}
-			error={!isValid}
-			endDecorator={decorator}
-			startDecorator={decorator}
-		/>
-	) : (
-		<div
-			onClick={() => {
-				setTypingText(props.text);
-				setIsEditing(true);
-			}}
-		>
-			{props.renderAsMarkdown ? (
-				<Markdown>{props.text}</Markdown>
+		setTypingText(text);
+		setIsEditing(false);
+	}, [text]);
+
+	return (
+		<Stack direction="row">
+			<Stack sx={{ mt: '10px' }}>
+				<SprocketTooltip text={isEditing ? 'Save' : 'Edit'}>
+					<IconButton onClick={toggleEditing} disabled={isEditing && !isValid} size="sm">
+						{isEditing ? <CheckIcon /> : <ModeEdit />}
+					</IconButton>
+				</SprocketTooltip>
+				{isEditing && (
+					<SprocketTooltip text="Cancel">
+						<IconButton onClick={() => setIsEditing(false)} size="sm">
+							<CancelIcon />
+						</IconButton>
+					</SprocketTooltip>
+				)}
+			</Stack>
+			{isEditing ? (
+				<Textarea
+					sx={{ width: '100%', mt: '10px' }}
+					variant="outlined"
+					value={typingText}
+					onChange={(e) => setTypingText(e.target.value)}
+					error={!isValid}
+				/>
 			) : (
-				<Typography level="body-md" sx={{ textAlign: 'left' }}>
-					{props.text}
-				</Typography>
+				<Box sx={{ px: '10px' }}>
+					<Markdown>{text}</Markdown>
+				</Box>
 			)}
-		</div>
+		</Stack>
 	);
 }

--- a/src/components/shared/input/EditorActions.tsx
+++ b/src/components/shared/input/EditorActions.tsx
@@ -9,7 +9,7 @@ interface EditorActionsProps {
 
 export function EditorActions({ copyText, format }: EditorActionsProps) {
 	return (
-		<Stack direction={'row'}>
+		<Stack direction="row">
 			{copyText != null && <CopyToClipboardButton copyText={copyText} />}
 			{format != null && <FormatButton onChange={format} />}
 		</Stack>

--- a/src/components/shared/input/SprocketEditor.tsx
+++ b/src/components/shared/input/SprocketEditor.tsx
@@ -1,86 +1,65 @@
 import { ReactNode, useEffect, useRef } from 'react';
-import { DiffEditor, DiffEditorProps, Editor, EditorProps, Monaco } from '@monaco-editor/react';
+import { Editor, EditorProps } from '@monaco-editor/react';
 import { defaultEditorOptions } from '../../../managers/MonacoInitManager';
 import { editor } from 'monaco-editor';
 import { useEditorTheme } from '../../../hooks/useEditorTheme';
 import { Box, Stack } from '@mui/joy';
 import { EditorActions } from './EditorActions';
 
-type SprocketEditorProps<TEditorProps extends EditorProps | DiffEditorProps, TIsDiff> = Omit<
-	TEditorProps,
-	'onMount'
-> & {
+type SprocketEditorProps = Omit<EditorProps, 'onMount'> & {
 	ActionBarItems?: ReactNode;
 	formatOnChange?: boolean;
-	isDiff?: TIsDiff;
-	onChange?: TIsDiff extends true ? never : EditorProps['onChange'];
 };
 
-export function SprocketEditor<TIsDiff extends boolean | undefined = undefined>({
+export function SprocketEditor({
 	ActionBarItems = <Box />,
 	formatOnChange = false,
-	isDiff = false,
+	options,
+	value,
 	...overrides
-}: SprocketEditorProps<TIsDiff extends true ? DiffEditorProps : EditorProps, TIsDiff>) {
-	const allEditorOptions = { ...defaultEditorOptions, ...overrides.options };
+}: SprocketEditorProps) {
+	const combinedOptions = { ...defaultEditorOptions, ...options };
 	const editorTheme = useEditorTheme();
-	const editorRef = useRef<editor.IStandaloneCodeEditor | editor.IStandaloneDiffEditor | null>(null);
-	const value = (overrides as EditorProps)?.value ?? (overrides as DiffEditorProps).original;
+	const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+
 	const format = async () => {
 		if (editorRef.current != null) {
-			let action: () => Promise<void>;
-			if (!isDiff) {
-				const current = editorRef.current as editor.IStandaloneCodeEditor;
-				action = async () => current?.getAction('editor.action.formatDocument')?.run();
-			} else {
-				const current = editorRef.current as editor.IStandaloneDiffEditor;
-				action = async () => {
-					const formatFirst = current.getOriginalEditor().getAction('editor.action.formatDocument')?.run();
-					const formatSecond = current.getModifiedEditor().getAction('editor.action.formatDocument')?.run();
-					await Promise.all([formatFirst, formatSecond]);
-				};
-			}
-			if (overrides?.options?.readOnly) {
-				editorRef.current?.updateOptions({ ...allEditorOptions, readOnly: false, originalEditable: true });
+			const current = editorRef.current;
+			const action = () => current?.getAction('editor.action.formatDocument')?.run();
+			if (options?.readOnly) {
+				editorRef.current?.updateOptions({ ...combinedOptions, readOnly: false });
 				await action();
-				editorRef.current?.updateOptions({ ...allEditorOptions, readOnly: true, originalEditable: false });
+				editorRef.current?.updateOptions({ ...combinedOptions, readOnly: true });
 			} else {
 				await action();
 			}
 		}
-	};
-
-	const handleEditorDidMount = (
-		editor: editor.IStandaloneCodeEditor | editor.IStandaloneDiffEditor,
-		_monaco: Monaco,
-	) => {
-		editorRef.current = editor;
-		format();
 	};
 
 	useEffect(() => {
-		if (overrides?.options != null) {
-			editorRef.current?.updateOptions(allEditorOptions);
+		if (options != null) {
+			editorRef.current?.updateOptions(combinedOptions);
 		}
-	}, [allEditorOptions]);
+	}, [combinedOptions]);
 
 	useEffect(() => {
 		if (formatOnChange) format();
 	}, [value, editorRef.current, formatOnChange]);
 
-	const EditorType = isDiff ? DiffEditor : Editor;
-
 	return (
 		<Box>
 			<Stack direction="row" justifyContent="space-between" alignItems="end">
 				{ActionBarItems}
-				<EditorActions copyText={isDiff ? undefined : value} format={format} />
+				<EditorActions copyText={value} format={format} />
 			</Stack>
-			<EditorType
+			<Editor
 				language={'typescript'}
 				theme={editorTheme}
-				options={allEditorOptions}
-				onMount={handleEditorDidMount}
+				options={combinedOptions}
+				onMount={(editor) => {
+					editorRef.current = editor;
+					format();
+				}}
 				value={value}
 				{...overrides}
 			/>

--- a/src/components/sidebar/SideDrawerActions.tsx
+++ b/src/components/sidebar/SideDrawerActions.tsx
@@ -8,8 +8,8 @@ import { OpenSecretsButton } from './buttons/OpenSecretsButton';
 
 export function SideDrawerActions() {
 	return (
-		<Stack direction={'row'} spacing={3} justifyContent="space-between">
-			<Stack direction={'row'} spacing={2}>
+		<Stack direction="row" gap={2} justifyContent="space-between">
+			<Stack direction="row" gap={1} flexWrap="wrap">
 				<ImportFromFileButton />
 				<NewButton />
 				<SaveButton />

--- a/src/components/sidebar/buttons/ImportFromFileButton.tsx
+++ b/src/components/sidebar/buttons/ImportFromFileButton.tsx
@@ -56,6 +56,7 @@ export function ImportFromFileButton() {
 										requests: Object.values(asData.requests ?? {}),
 										environments: Object.values(asData.environments ?? {}),
 										scripts: Object.values(asData.scripts ?? {}),
+										secrets: Object.values(asData.secrets ?? []),
 									};
 									dispatch(InjectLoadedData(toInject));
 								}

--- a/src/components/sidebar/buttons/OpenSecretsButton.tsx
+++ b/src/components/sidebar/buttons/OpenSecretsButton.tsx
@@ -3,21 +3,24 @@ import { IconButton } from '@mui/joy';
 import { useAppDispatch } from '../../../state/store';
 import { tabsActions } from '../../../state/tabs/slice';
 import { ELEMENT_ID } from '../../../constants/uiElementIds';
+import { SprocketTooltip } from '../../shared/SprocketTooltip';
 
 export function OpenSecretsButton() {
 	const dispatch = useAppDispatch();
 	return (
-		<IconButton
-			id="toggle-mode"
-			size="sm"
-			variant="soft"
-			color="neutral"
-			onClick={() => {
-				dispatch(tabsActions.addTabs({ [ELEMENT_ID.secrets]: 'secrets' }));
-				dispatch(tabsActions.setSelectedTab(ELEMENT_ID.secrets));
-			}}
-		>
-			<Key />
-		</IconButton>
+		<SprocketTooltip text="User Secrets">
+			<IconButton
+				id="toggle-mode"
+				size="sm"
+				variant="soft"
+				color="neutral"
+				onClick={() => {
+					dispatch(tabsActions.addTabs({ [ELEMENT_ID.secrets]: 'secrets' }));
+					dispatch(tabsActions.setSelectedTab(ELEMENT_ID.secrets));
+				}}
+			>
+				<Key />
+			</IconButton>
+		</SprocketTooltip>
 	);
 }

--- a/src/components/sidebar/file-system/EndpointFileSystem.tsx
+++ b/src/components/sidebar/file-system/EndpointFileSystem.tsx
@@ -45,7 +45,7 @@ export function EndpointFileSystem({ endpointId }: EndpointFileSystemProps) {
 						</Chip>
 					</ListSubheader>
 					<ListItemContent>
-						<EllipsisTypography>{endpoint.name}</EllipsisTypography>
+						<EllipsisTypography fontSize="sm">{endpoint.name}</EllipsisTypography>
 					</ListItemContent>
 				</>
 			}

--- a/src/hooks/useComputedEnvironment.ts
+++ b/src/hooks/useComputedEnvironment.ts
@@ -1,0 +1,43 @@
+import { useSelector } from 'react-redux';
+import {
+	selectEndpointById,
+	selectEnvironments,
+	selectRequestsById,
+	selectSecrets,
+	selectSelectedEnvironmentValue,
+	selectServiceSelectedEnvironmentValue,
+} from '../state/active/selectors';
+import { EnvironmentContextResolver } from '../managers/EnvironmentContextResolver';
+
+function useRootEnvironmentArgs() {
+	const secrets = useSelector(selectSecrets);
+	const rootEnv = useSelector(selectSelectedEnvironmentValue);
+	const environments = useSelector(selectEnvironments);
+	return { secrets, rootEnv, rootAncestors: Object.values(environments) };
+}
+
+export function useComputedRootEnvironment() {
+	const args = useRootEnvironmentArgs();
+	return EnvironmentContextResolver.buildEnvironmentVariables(args).toArray();
+}
+
+export function useComputedServiceEnvironment(id: string) {
+	const args = useRootEnvironmentArgs();
+	const servEnv = useSelector((state) => selectServiceSelectedEnvironmentValue(state, id));
+	return EnvironmentContextResolver.buildEnvironmentVariables({
+		...args,
+		servEnv,
+	}).toArray();
+}
+
+export function useComputedRequestEnvironment(id: string) {
+	const args = useRootEnvironmentArgs();
+	const request = useSelector((state) => selectRequestsById(state, id));
+	const endpoint = useSelector((state) => selectEndpointById(state, request.endpointId));
+	const servEnv = useSelector((state) => selectServiceSelectedEnvironmentValue(state, endpoint.serviceId));
+	return EnvironmentContextResolver.buildEnvironmentVariables({
+		...args,
+		reqEnv: request.environmentOverride,
+		servEnv,
+	}).toArray();
+}

--- a/src/hooks/useEditorTheme.ts
+++ b/src/hooks/useEditorTheme.ts
@@ -1,7 +1,6 @@
 import { useColorScheme } from '@mui/joy';
+import { getEditorTheme } from '../utils/style';
 
 export function useEditorTheme() {
-	const { mode, systemMode } = useColorScheme();
-	const resolvedMode = mode === 'system' ? systemMode : mode;
-	return resolvedMode === 'dark' ? 'vs-dark' : resolvedMode;
+	return getEditorTheme(useColorScheme());
 }

--- a/src/managers/NetworkRequestManager.ts
+++ b/src/managers/NetworkRequestManager.ts
@@ -150,7 +150,7 @@ class NetworkRequestManager {
 		});
 
 		const fullQueryParams = new OrderedKeyValuePairs(endpoint.baseQueryParams, request.queryParams);
-		let queryParamStr = queryParamsToString(fullQueryParams.toArray(), (text) =>
+		let queryParamStr = queryParamsToString(fullQueryParams.toArray(), true, (text) =>
 			EnvironmentContextResolver.resolveVariablesForString(text, envValues),
 		);
 		if (queryParamStr) {
@@ -182,7 +182,7 @@ class NetworkRequestManager {
 			url: `${url}${queryParamStr}`,
 			method: endpoint.verb,
 			body: networkRequestBodyText,
-			headers: headers.toArray(),
+			headers: headers.toObject(),
 			dateTime: new Date().getTime(),
 			bodyType: request.rawType,
 		};

--- a/src/managers/data/WorkspaceDataManager.ts
+++ b/src/managers/data/WorkspaceDataManager.ts
@@ -132,7 +132,7 @@ export class WorkspaceDataManager {
 			data: `${base}.json`,
 			history: `${base}_history.json`,
 			metadata: `${base}_metadata.json`,
-			uiMetadata: `${base}_ui_metadata`,
+			uiMetadata: `${base}_ui_metadata.json`,
 			secrets: `${base}_secrets.json`,
 		};
 	}
@@ -191,7 +191,7 @@ export class WorkspaceDataManager {
 			fileSystemManager.createFileIfNotExists(paths.history, []),
 			fileSystemManager.createFileIfNotExists(paths.uiMetadata, uiMetadata),
 			fileSystemManager.createFileIfNotExists(paths.metadata, workspace),
-			fileSystemManager.createFileIfNotExists(paths.secrets, {}),
+			fileSystemManager.createFileIfNotExists(paths.secrets, []),
 		];
 		const results = await Promise.all(promises);
 		return results.includes(true);

--- a/src/managers/data/WorkspaceDataManager.ts
+++ b/src/managers/data/WorkspaceDataManager.ts
@@ -80,8 +80,8 @@ export class WorkspaceDataManager {
 		}
 
 		const dataToWrite = JSON.stringify(
-			data,
-			nullifyProperties<WorkspaceData & EndpointRequest>('history', 'settings', 'metadata', 'secrets', 'uiMetadata'),
+			{ ...data, secrets: data.secrets.map(({ key }) => ({ key, value: '' })) },
+			nullifyProperties<WorkspaceData & EndpointRequest>('history', 'settings', 'metadata', 'uiMetadata'),
 		);
 
 		await writeTextFile(filePath, dataToWrite);

--- a/src/state/active/thunks/environments.ts
+++ b/src/state/active/thunks/environments.ts
@@ -1,7 +1,13 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { Environment } from '../../../types/application-data/application-data';
 import { RootState } from '../../store';
-import { insertEnvironment, deleteEnvironmentFromState } from '../slice';
+import {
+	insertEnvironment,
+	deleteEnvironmentFromState,
+	removeLinkedEnv,
+	addLinkedEnv,
+	UpdateLinkedEnv,
+} from '../slice';
 import { tabsActions } from '../../tabs/slice';
 import { cloneEnv } from '../../../utils/application';
 
@@ -31,5 +37,18 @@ export const deleteEnvironmentById = createAsyncThunk<void, string, { state: Roo
 	async (id, thunk) => {
 		thunk.dispatch(tabsActions.closeTab(id));
 		thunk.dispatch(deleteEnvironmentFromState(id));
+	},
+);
+
+interface RelinkEnvironmentsArgs extends Omit<UpdateLinkedEnv, 'envId'> {
+	remove: string[];
+	add: string[];
+}
+
+export const relinkEnvironments = createAsyncThunk<void, RelinkEnvironmentsArgs, { state: RootState }>(
+	'active/deleteEnvironmentById',
+	async ({ remove, add, serviceEnvId, serviceId }, thunk) => {
+		remove.forEach((envId) => thunk.dispatch(removeLinkedEnv({ envId, serviceEnvId, serviceId })));
+		add.forEach((envId) => thunk.dispatch(addLinkedEnv({ envId, serviceEnvId, serviceId })));
 	},
 );

--- a/src/state/active/thunks/services.ts
+++ b/src/state/active/thunks/services.ts
@@ -26,6 +26,17 @@ export const cloneService = createAsyncThunk<string, CloneServiceInput, { state:
 	},
 );
 
+type NewServiceArgs = Pick<Service, 'baseUrl' | 'description' | 'name'>;
+
+export const addNewService = createAsyncThunk<string, NewServiceArgs, { state: RootState }>(
+	'active/addNewService',
+	async (serviceData, thunk) => {
+		const newService = { ...createNewServiceObject(), ...serviceData };
+		thunk.dispatch(insertService(newService));
+		return newService.id;
+	},
+);
+
 export const cloneServiceFromId = createAsyncThunk<void, string, { state: RootState }>(
 	'active/cloneServiceFromId',
 	async (oldId, thunk) => {

--- a/src/types/application-data/application-data.tsx
+++ b/src/types/application-data/application-data.tsx
@@ -68,7 +68,7 @@ export type EndpointRequest<TRequestBodyType extends RequestBodyType = RequestBo
 export type NetworkFetchRequest = {
 	method: RESTfulRequestVerb;
 	url: string;
-	headers: SPHeaders;
+	headers: Record<string, string>;
 	body: string;
 	bodyType?: RawBodyType;
 	dateTime: number;

--- a/src/types/application-data/application-data.tsx
+++ b/src/types/application-data/application-data.tsx
@@ -101,9 +101,7 @@ export type Environment = {
 	pairs: KeyValuePair[];
 };
 
-type LinkedEnv = { serviceId: string; envId: string };
-
-export type RootEnvironment = Environment & { linked?: LinkedEnv[] };
+export type RootEnvironment = Environment & { linked?: Record<string, string | null>; parents?: string[] };
 
 export type QueryParams = KeyValuePair<KeyValueValues>[];
 export type SPHeaders = KeyValuePair[];
@@ -121,6 +119,7 @@ export type Service<TBaseUrl extends string = string> = {
 	endpointIds: string[];
 	preRequestScript?: string;
 	postRequestScript?: string;
+	linkedEnvMode?: boolean;
 };
 
 export type WorkspaceMetadata = {

--- a/src/utils/application.ts
+++ b/src/utils/application.ts
@@ -51,6 +51,7 @@ export function getEnvValuesFromData(data: WorkspaceData, requestId?: string): B
 	const values: BuildEnvironmentVariablesArgs = {
 		secrets: data.secrets,
 		rootEnv: data.selectedEnvironment == null ? null : data.environments[data.selectedEnvironment],
+		rootAncestors: Object.values(data.environments),
 	};
 	if (requestId != null) {
 		const request = data.requests[requestId];

--- a/src/utils/application.ts
+++ b/src/utils/application.ts
@@ -5,6 +5,7 @@ import { Environment, QueryParams, WorkspaceData } from '../types/application-da
 
 export function queryParamsToString(
 	queryParams: QueryParams,
+	encoded = false,
 	replaceFunc: (text: string) => string = (element) => element,
 ): string {
 	const searchParams = new URLSearchParams();
@@ -15,7 +16,7 @@ export function queryParamsToString(
 			searchParams.append(replaceFunc(key), replaceFunc(value ?? ''));
 		}
 	});
-	return searchParams.toString();
+	return encoded ? searchParams.toString() : decodeURIComponent(searchParams.toString());
 }
 
 export function cloneEnv(env?: Partial<Environment>, nameMod?: string): Environment {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,13 +1,3 @@
-export function keepStringLengthReasonable(string: string, reasonableLength = 30) {
-	if (string == null) {
-		return '';
-	}
-	if (string.length <= reasonableLength) {
-		return string;
-	}
-	return `${string.slice(0, reasonableLength - 3)}...`;
-}
-
 function getLongestCommonSubstringStartingAtBeginningIndex(string1: string, string2: string): number {
 	let i;
 	for (i = 0; i < string1.length && i < string2.length; i++) {


### PR DESCRIPTION
added features/improvements
* dropdown for service environments
* actionbar for additional actions on the same line as the default editor actions
* better string breaking for urls in some places
* better spacing on some pages
* auto-ellipses have been added to the text edit component
* text edit component no longer wiggles the content of the page
* environment linking! #97
* better UI for the service tab in general #100 

requests - added
* tabs should be long
* env inheritance
* empty string user secrets on export

fixed pre-existing bugs
* spacing in sidebar now doesn't break if you squish the sidebar too much
* new services should not have (copy) in the name unless they ARE a copy

fixed bugs introduced after 1.3.0
* request params are not populating correctly & replacing correctly 
* mysterious white screen of death on request -> response -> details page?
* multiple service environments 
* secrets initialization for already-created workspaces is broken 
* requests cannot push headers 
* correct typing on making requests 
* diff tool original.request.headers.toJSON type error
* user secrets button tooltip
* occasionally the editor will not auto-format on load
* I've about had it up to here with the editor not formatting stuff

## things I'll solve in a follow-up PR
* whatever is going on with the editor values not updating/causing an infiniloop if I use useEffect
* tweaking the number editing width for request history
* workspace bug (in issues)
* refresh environment links when you edit them so they're in sync as soon as they get edited
* related to the above, I'd like to make the env linking/relinking a side effect, not in the set function itself
